### PR TITLE
Exadata info

### DIFF
--- a/sql/edb360_5g_exadata.sql
+++ b/sql/edb360_5g_exadata.sql
@@ -453,17 +453,29 @@ BEGIN
 -- celliorm.sql (v1.0) 
 -- Tanel Poder
 -- http://blog.tanelpoder.com
+WITH cell_config AS (
+    ( SELECT /*+ materialize */
+        cellname,
+        CASE
+                WHEN confval LIKE '%interdatabaseplan%' THEN replace(confval,'interdatabaseplan','iormplan')
+                ELSE confval
+            END
+        confval
+      FROM
+        &&v_object_prefix.cell_config  -- gv isn't needed, all cells should be visible in all instances
+      WHERE
+        conftype = 'IORM'
+    )
+)
 SELECT
     cellname cv_cellname
-  , CAST(extract(xmltype(confval), '/cli-output/interdatabaseplan/objective/text()') AS VARCHAR2(20)) objective
-  , CAST(extract(xmltype(confval), '/cli-output/interdatabaseplan/status/text()')    AS VARCHAR2(15)) status
-  , CAST(extract(xmltype(confval), '/cli-output/interdatabaseplan/name/text()')      AS VARCHAR2(30)) interdb_plan
-  , CAST(extract(xmltype(confval), '/cli-output/interdatabaseplan/catPlan/text()')   AS VARCHAR2(30)) cat_plan
-  , CAST(extract(xmltype(confval), '/cli-output/interdatabaseplan/dbPlan/text()')    AS VARCHAR2(30)) db_plan
+  , CAST(extract(xmltype(confval), '/cli-output/iormplan/objective/text()') AS VARCHAR2(20)) objective
+  , CAST(extract(xmltype(confval), '/cli-output/iormplan/status/text()')    AS VARCHAR2(15)) status
+  , CAST(extract(xmltype(confval), '/cli-output/iormplan/name/text()')      AS VARCHAR2(30)) interdb_plan
+  , CAST(extract(xmltype(confval), '/cli-output/iormplan/catPlan/text()')   AS VARCHAR2(30)) cat_plan
+  , CAST(extract(xmltype(confval), '/cli-output/iormplan/dbPlan/text()')    AS VARCHAR2(30)) db_plan
 FROM 
-    &&v_object_prefix.cell_config  -- gv isn't needed, all cells should be visible in all instances
-WHERE 
-    conftype = 'IORM'
+    cell_config
 ORDER BY
     cv_cellname
 ]';
@@ -637,307 +649,145 @@ BEGIN
 -- exadisktopo.sql (v1.0) 
 -- Tanel Poder
 -- http://blog.tanelpoder.com
-WITH
-  pd AS (
+WITH pd AS (
     SELECT /*+ MATERIALIZE */
-        c.cellname
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/name/text()')                          AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/diskType/text()')                      AS VARCHAR2(100)) diskType          
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/luns/text()')                          AS VARCHAR2(100)) luns              
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/makeModel/text()')                     AS VARCHAR2(100)) makeModel         
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalFirmware/text()')              AS VARCHAR2(100)) physicalFirmware  
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalInsertTime/text()')            AS VARCHAR2(100)) physicalInsertTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalSerial/text()')                AS VARCHAR2(100)) physicalSerial    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalSize/text()')                  AS VARCHAR2(100)) physicalSize      
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/slotNumber/text()')                    AS VARCHAR2(100)) slotNumber        
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/status/text()')                        AS VARCHAR2(100)) status            
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/id/text()')                            AS VARCHAR2(100)) id                
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/key_500/text()')                       AS VARCHAR2(100)) key_500           
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/predfailStatus/text()')                AS VARCHAR2(100)) predfailStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/poorPerfStatus/text()')                AS VARCHAR2(100)) poorPerfStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/wtCachingStatus/text()')               AS VARCHAR2(100)) wtCachingStatus   
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/peerFailStatus/text()')                AS VARCHAR2(100)) peerFailStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/criticalStatus/text()')                AS VARCHAR2(100)) criticalStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errCmdTimeoutCount/text()')            AS VARCHAR2(100)) errCmdTimeoutCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errHardReadCount/text()')              AS VARCHAR2(100)) errHardReadCount  
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errHardWriteCount/text()')             AS VARCHAR2(100)) errHardWriteCount 
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errMediaCount/text()')                 AS VARCHAR2(100)) errMediaCount     
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errOtherCount/text()')                 AS VARCHAR2(100)) errOtherCount     
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errSeekCount/text()')                  AS VARCHAR2(100)) errSeekCount      
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/sectorRemapCount/text()')              AS VARCHAR2(100)) sectorRemapCount  
+        c.cellname,
+        CAST(extractvalue(value(v),'/physicaldisk/name/text()') AS VARCHAR2(100) ) name,
+        CAST(extractvalue(value(v),'/physicaldisk/diskType/text()') AS VARCHAR2(100) ) disktype,
+        CAST(extractvalue(value(v),'/physicaldisk/luns/text()') AS VARCHAR2(100) ) luns,
+        CAST(extractvalue(value(v),'/physicaldisk/makeModel/text()') AS VARCHAR2(100) ) makemodel,
+        CAST(extractvalue(value(v),'/physicaldisk/physicalFirmware/text()') AS VARCHAR2(100) ) physicalfirmware,
+        CAST(extractvalue(value(v),'/physicaldisk/physicalInsertTime/text()') AS VARCHAR2(100) ) physicalinserttime,
+        CAST(extractvalue(value(v),'/physicaldisk/physicalSerial/text()') AS VARCHAR2(100) ) physicalserial,
+        CAST(extractvalue(value(v),'/physicaldisk/physicalSize/text()') AS VARCHAR2(100) ) physicalsize,
+        CAST(extractvalue(value(v),'/physicaldisk/slotNumber/text()') AS VARCHAR2(100) ) slotnumber,
+        CAST(extractvalue(value(v),'/physicaldisk/status/text()') AS VARCHAR2(100) ) status,
+        CAST(extractvalue(value(v),'/physicaldisk/id/text()') AS VARCHAR2(100) ) id,
+        CAST(extractvalue(value(v),'/physicaldisk/key_500/text()') AS VARCHAR2(100) ) key_500,
+        CAST(extractvalue(value(v),'/physicaldisk/predfailStatus/text()') AS VARCHAR2(100) ) predfailstatus,
+        CAST(extractvalue(value(v),'/physicaldisk/poorPerfStatus/text()') AS VARCHAR2(100) ) poorperfstatus,
+        CAST(extractvalue(value(v),'/physicaldisk/wtCachingStatus/text()') AS VARCHAR2(100) ) wtcachingstatus,
+        CAST(extractvalue(value(v),'/physicaldisk/peerFailStatus/text()') AS VARCHAR2(100) ) peerfailstatus,
+        CAST(extractvalue(value(v),'/physicaldisk/criticalStatus/text()') AS VARCHAR2(100) ) criticalstatus,
+        CAST(extractvalue(value(v),'/physicaldisk/errCmdTimeoutCount/text()') AS VARCHAR2(100) ) errcmdtimeoutcount,
+        CAST(extractvalue(value(v),'/physicaldisk/errHardReadCount/text()') AS VARCHAR2(100) ) errhardreadcount,
+        CAST(extractvalue(value(v),'/physicaldisk/errHardWriteCount/text()') AS VARCHAR2(100) ) errhardwritecount,
+        CAST(extractvalue(value(v),'/physicaldisk/errMediaCount/text()') AS VARCHAR2(100) ) errmediacount,
+        CAST(extractvalue(value(v),'/physicaldisk/errOtherCount/text()') AS VARCHAR2(100) ) errothercount,
+        CAST(extractvalue(value(v),'/physicaldisk/errSeekCount/text()') AS VARCHAR2(100) ) errseekcount,
+        CAST(extractvalue(value(v),'/physicaldisk/sectorRemapCount/text()') AS VARCHAR2(100) ) sectorremapcount
     FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/physicaldisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
+        &&v_object_prefix.cell_config c,
+        TABLE ( xmlsequence(extract(xmltype(c.confval),'/cli-output/physicaldisk') ) ) v  -- gv isn't needed, all cells should be visible in all instances
+    WHERE
         c.conftype = 'PHYSICALDISKS'
-),
- cd AS (
+),cd AS (
     SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/name/text()')                              AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/comment        /text()')                   AS VARCHAR2(100)) disk_comment
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/creationTime   /text()')                   AS VARCHAR2(100)) creationTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/deviceName     /text()')                   AS VARCHAR2(100)) deviceName
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/devicePartition/text()')                   AS VARCHAR2(100)) devicePartition
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/diskType       /text()')                   AS VARCHAR2(100)) diskType
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/errorCount     /text()')                   AS VARCHAR2(100)) errorCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/freeSpace      /text()')                   AS VARCHAR2(100)) freeSpace
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/id             /text()')                   AS VARCHAR2(100)) id
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/interleaving   /text()')                   AS VARCHAR2(100)) interleaving
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/lun            /text()')                   AS VARCHAR2(100)) lun
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/physicalDisk   /text()')                   AS VARCHAR2(100)) physicalDisk
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/size           /text()')                   AS VARCHAR2(100)) disk_size
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/status         /text()')                   AS VARCHAR2(100)) status
+        c.cellname,
+        CAST(extractvalue(value(v),'/celldisk/name/text()') AS VARCHAR2(100) ) name,
+        CAST(extractvalue(value(v),'/celldisk/comment        /text()') AS VARCHAR2(100) ) disk_comment,
+        CAST(extractvalue(value(v),'/celldisk/creationTime   /text()') AS VARCHAR2(100) ) creationtime,
+        CAST(extractvalue(value(v),'/celldisk/deviceName     /text()') AS VARCHAR2(100) ) devicename,
+        CAST(extractvalue(value(v),'/celldisk/devicePartition/text()') AS VARCHAR2(100) ) devicepartition,
+        CAST(extractvalue(value(v),'/celldisk/diskType       /text()') AS VARCHAR2(100) ) disktype,
+        CAST(extractvalue(value(v),'/celldisk/errorCount     /text()') AS VARCHAR2(100) ) errorcount,
+        CAST(extractvalue(value(v),'/celldisk/freeSpace      /text()') AS VARCHAR2(100) ) freespace,
+        CAST(extractvalue(value(v),'/celldisk/id             /text()') AS VARCHAR2(100) ) id,
+        CAST(extractvalue(value(v),'/celldisk/interleaving   /text()') AS VARCHAR2(100) ) interleaving,
+        CAST(extractvalue(value(v),'/celldisk/lun            /text()') AS VARCHAR2(100) ) lun,
+        CAST(extractvalue(value(v),'/celldisk/physicalDisk   /text()') AS VARCHAR2(100) ) physicaldisk,
+        CAST(extractvalue(value(v),'/celldisk/size           /text()') AS VARCHAR2(100) ) disk_size,
+        CAST(extractvalue(value(v),'/celldisk/status         /text()') AS VARCHAR2(100) ) status
     FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/celldisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
+        &&v_object_prefix.cell_config c,
+        TABLE ( xmlsequence(extract(xmltype(c.confval),'/cli-output/celldisk') ) ) v  -- gv isn't needed, all cells should be visible in all instances
+    WHERE
         c.conftype = 'CELLDISKS'
-),
- gd AS (
+),gd AS (
     SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/name/text()')                               AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmDiskgroupName/text()')                   AS VARCHAR2(100)) asmDiskgroupName 
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmDiskName     /text()')                   AS VARCHAR2(100)) asmDiskName
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmFailGroupName/text()')                   AS VARCHAR2(100)) asmFailGroupName
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/availableTo     /text()')                   AS VARCHAR2(100)) availableTo
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/cachingPolicy   /text()')                   AS VARCHAR2(100)) cachingPolicy
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/cellDisk        /text()')                   AS VARCHAR2(100)) cellDisk
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/comment         /text()')                   AS VARCHAR2(100)) disk_comment
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/creationTime    /text()')                   AS VARCHAR2(100)) creationTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/diskType        /text()')                   AS VARCHAR2(100)) diskType
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/errorCount      /text()')                   AS VARCHAR2(100)) errorCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/id              /text()')                   AS VARCHAR2(100)) id
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/offset          /text()')                   AS VARCHAR2(100)) offset
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/size            /text()')                   AS VARCHAR2(100)) disk_size
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/status          /text()')                   AS VARCHAR2(100)) status
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/cachedBy        /text()')                   AS VARCHAR2(100)) cachedBy
+        c.cellname,
+        CAST(extractvalue(value(v),'/griddisk/name/text()') AS VARCHAR2(100) ) name,
+        CAST(extractvalue(value(v),'/griddisk/asmDiskgroupName/text()') AS VARCHAR2(100) ) asmdiskgroupname,
+        CAST(extractvalue(value(v),'/griddisk/asmDiskName     /text()') AS VARCHAR2(100) ) asmdiskname,
+        CAST(extractvalue(value(v),'/griddisk/asmFailGroupName/text()') AS VARCHAR2(100) ) asmfailgroupname,
+        CAST(extractvalue(value(v),'/griddisk/availableTo     /text()') AS VARCHAR2(100) ) availableto,
+        CAST(extractvalue(value(v),'/griddisk/cachingPolicy   /text()') AS VARCHAR2(100) ) cachingpolicy,
+        CAST(extractvalue(value(v),'/griddisk/cellDisk        /text()') AS VARCHAR2(100) ) celldisk,
+        CAST(extractvalue(value(v),'/griddisk/comment         /text()') AS VARCHAR2(100) ) disk_comment,
+        CAST(extractvalue(value(v),'/griddisk/creationTime    /text()') AS VARCHAR2(100) ) creationtime,
+        CAST(extractvalue(value(v),'/griddisk/diskType        /text()') AS VARCHAR2(100) ) disktype,
+        CAST(extractvalue(value(v),'/griddisk/errorCount      /text()') AS VARCHAR2(100) ) errorcount,
+        CAST(extractvalue(value(v),'/griddisk/id              /text()') AS VARCHAR2(100) ) id,
+        CAST(extractvalue(value(v),'/griddisk/offset          /text()') AS VARCHAR2(100) ) offset,
+        CAST(extractvalue(value(v),'/griddisk/size            /text()') AS VARCHAR2(100) ) disk_size,
+        CAST(extractvalue(value(v),'/griddisk/status          /text()') AS VARCHAR2(100) ) status,
+        CAST(extractvalue(value(v),'/griddisk/cachedBy        /text()') AS VARCHAR2(100) ) cachedby
     FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/griddisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
+        &&v_object_prefix.cell_config c,
+        TABLE ( xmlsequence(extract(xmltype(c.confval),'/cli-output/griddisk') ) ) v  -- gv isn't needed, all cells should be visible in all instances
+    WHERE
         c.conftype = 'GRIDDISKS'
-),
- lun AS (
+),lun AS (
     SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/cellDisk         /text()')              AS VARCHAR2(100)) cellDisk      
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/deviceName       /text()')              AS VARCHAR2(100)) deviceName    
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/diskType         /text()')              AS VARCHAR2(100)) diskType      
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/id               /text()')              AS VARCHAR2(100)) id            
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/isSystemLun      /text()')              AS VARCHAR2(100)) isSystemLun   
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunAutoCreate    /text()')              AS VARCHAR2(100)) lunAutoCreate 
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunSize          /text()')              AS VARCHAR2(100)) lunSize       
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/physicalDrives   /text()')              AS VARCHAR2(100)) physicalDrives
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/raidLevel        /text()')              AS VARCHAR2(100)) raidLevel
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunWriteCacheMode/text()')              AS VARCHAR2(100)) lunWriteCacheMode
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/status           /text()')              AS VARCHAR2(100)) status        
+        c.cellname,
+        CAST(extractvalue(value(v),'/lun/cellDisk         /text()') AS VARCHAR2(100) ) celldisk,
+        CAST(extractvalue(value(v),'/lun/deviceName       /text()') AS VARCHAR2(100) ) devicename,
+        CAST(extractvalue(value(v),'/lun/diskType         /text()') AS VARCHAR2(100) ) disktype,
+        CAST(extractvalue(value(v),'/lun/id               /text()') AS VARCHAR2(100) ) id,
+        CAST(extractvalue(value(v),'/lun/isSystemLun      /text()') AS VARCHAR2(100) ) issystemlun,
+        CAST(extractvalue(value(v),'/lun/lunAutoCreate    /text()') AS VARCHAR2(100) ) lunautocreate,
+        CAST(extractvalue(value(v),'/lun/lunSize          /text()') AS VARCHAR2(100) ) lunsize,
+        CAST(extractvalue(value(v),'/lun/physicalDrives   /text()') AS VARCHAR2(100) ) physicaldrives,
+        CAST(extractvalue(value(v),'/lun/raidLevel        /text()') AS VARCHAR2(100) ) raidlevel,
+        CAST(extractvalue(value(v),'/lun/lunWriteCacheMode/text()') AS VARCHAR2(100) ) lunwritecachemode,
+        CAST(extractvalue(value(v),'/lun/status           /text()') AS VARCHAR2(100) ) status
     FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/lun'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
+        &&v_object_prefix.cell_config c,
+        TABLE ( xmlsequence(extract(xmltype(c.confval),'/cli-output/lun') ) ) v  -- gv isn't needed, all cells should be visible in all instances
+    WHERE
         c.conftype = 'LUNS'
-)
- , ad  AS (SELECT /*+ MATERIALIZE */ * FROM &&v_object_prefix.asm_disk)
- , adg AS (SELECT /*+ MATERIALIZE */ * FROM &&v_object_prefix.asm_diskgroup)
-SELECT 
-    adg.name                        asm_diskgroup
-  , ad.name                         asm_disk
-  , gd.name                         griddisk_name
-  , cd.name                         celldisk_name
-  , pd.cellname
-  , SUBSTR(cd.devicepartition,1,20) cd_devicepart
-  , pd.name                         physdisk_name
-  , SUBSTR(pd.status,1,20)          physdisk_status
-  , lun.lunWriteCacheMode
-  , gd.cachedBy
---  , SUBSTR(cd.devicename,1,20)      cd_devicename
---  , SUBSTR(lun.devicename,1,20)     lun_devicename
---    disktype
-FROM
-    gd
-  , cd
-  , pd
-  , lun
-  , ad
-  , adg
-WHERE
-    ad.group_number = adg.group_number (+)
-AND gd.asmdiskname = ad.name (+)
-AND cd.name = gd.cellDisk (+)
-AND pd.id = cd.physicalDisk (+)
---AND cd.name = lun.celldisk (+) -- as per Jie Wu
-AND cd.lun=lun.ID(+)
---GROUP BY
---    cellname
---  , disktype
---  , status
+),ad AS (
+    SELECT /*+ MATERIALIZE */
+        *
+    FROM
+        &&v_object_prefix.asm_disk
+),adg AS (
+    SELECT /*+ MATERIALIZE */
+        dg.*,
+        length(dg.name) namesize
+    FROM
+        &&v_object_prefix.asm_diskgroup dg
+) SELECT
+    adg.name asm_diskgroup,
+    adg.state,
+    ad.label asm_disk,
+    gd.asmdiskname griddisk_name,
+    cd.name celldisk_name,
+    pd.cellname,
+    substr(cd.devicepartition,1,20) cd_devicepart,
+    pd.name physdisk_name,
+    substr(pd.status,1,20) physdisk_status,
+    lun.lunwritecachemode,
+    gd.cachedby
+-- , SUBSTR(cd.devicename,1,20)      cd_devicename
+-- , SUBSTR(lun.devicename,1,20)     lun_devicename
+--    disktype*/
+  FROM
+    adg
+    LEFT OUTER JOIN ad ON ad.group_number = adg.group_number
+                          AND substr(ad.label,1,adg.namesize) = adg.name
+    JOIN gd ON upper(gd.asmdiskname) = upper(ad.label)
+    RIGHT OUTER JOIN cd ON cd.name = gd.celldisk
+    RIGHT OUTER JOIN pd ON cd.physicaldisk = pd.physicalserial
+    RIGHT OUTER JOIN lun ON cd.cellname = lun.cellname
+                            AND cd.devicename = lun.devicename 
 ORDER BY
---    disktype
-    asm_diskgroup
-  , asm_disk
-  , griddisk_name
-  , celldisk_name
-  , physdisk_name
-  , cellname
-]';
-END;
-/
-@@&&skip_10g_script.edb360_9a_pre_one.sql
-CLEAR BREAKS
-
-COL cellname            HEAD CELLNAME       FOR A20
-COL celldisk_name       HEAD CELLDISK       FOR A30
-COL physdisk_name       HEAD PHYSDISK       FOR A30
-COL griddisk_name       HEAD GRIDDISK       FOR A30
-COL asmdisk_name        HEAD ASMDISK        FOR A30
-BREAK ON cellname SKIP 1
-
-DEF title = 'Cell Disk Topology2';
-DEF main_table = '&&v_view_prefix.CELL_CONFIG';
-BEGIN
-  :sql_text := q'[
--- exadisktopo2.sql (v1.0) 
--- Tanel Poder
--- http://blog.tanelpoder.com
-WITH
-  pd AS (
-    SELECT /*+ MATERIALIZE */
-        c.cellname
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/name/text()')                          AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/diskType/text()')                      AS VARCHAR2(100)) diskType          
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/luns/text()')                          AS VARCHAR2(100)) luns              
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/makeModel/text()')                     AS VARCHAR2(100)) makeModel         
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalFirmware/text()')              AS VARCHAR2(100)) physicalFirmware  
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalInsertTime/text()')            AS VARCHAR2(100)) physicalInsertTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalSerial/text()')                AS VARCHAR2(100)) physicalSerial    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/physicalSize/text()')                  AS VARCHAR2(100)) physicalSize      
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/slotNumber/text()')                    AS VARCHAR2(100)) slotNumber        
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/status/text()')                        AS VARCHAR2(100)) status            
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/id/text()')                            AS VARCHAR2(100)) id                
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/key_500/text()')                       AS VARCHAR2(100)) key_500           
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/predfailStatus/text()')                AS VARCHAR2(100)) predfailStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/poorPerfStatus/text()')                AS VARCHAR2(100)) poorPerfStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/wtCachingStatus/text()')               AS VARCHAR2(100)) wtCachingStatus   
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/peerFailStatus/text()')                AS VARCHAR2(100)) peerFailStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/criticalStatus/text()')                AS VARCHAR2(100)) criticalStatus    
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errCmdTimeoutCount/text()')            AS VARCHAR2(100)) errCmdTimeoutCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errHardReadCount/text()')              AS VARCHAR2(100)) errHardReadCount  
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errHardWriteCount/text()')             AS VARCHAR2(100)) errHardWriteCount 
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errMediaCount/text()')                 AS VARCHAR2(100)) errMediaCount     
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errOtherCount/text()')                 AS VARCHAR2(100)) errOtherCount     
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/errSeekCount/text()')                  AS VARCHAR2(100)) errSeekCount      
-      , CAST(EXTRACTVALUE(VALUE(v), '/physicaldisk/sectorRemapCount/text()')              AS VARCHAR2(100)) sectorRemapCount  
-    FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/physicaldisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
-        c.conftype = 'PHYSICALDISKS'
-),
- cd AS (
-    SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/name/text()')                              AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/comment        /text()')                   AS VARCHAR2(100)) disk_comment
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/creationTime   /text()')                   AS VARCHAR2(100)) creationTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/deviceName     /text()')                   AS VARCHAR2(100)) deviceName
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/devicePartition/text()')                   AS VARCHAR2(100)) devicePartition
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/diskType       /text()')                   AS VARCHAR2(100)) diskType
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/errorCount     /text()')                   AS VARCHAR2(100)) errorCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/freeSpace      /text()')                   AS VARCHAR2(100)) freeSpace
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/id             /text()')                   AS VARCHAR2(100)) id
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/interleaving   /text()')                   AS VARCHAR2(100)) interleaving
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/lun            /text()')                   AS VARCHAR2(100)) lun
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/physicalDisk   /text()')                   AS VARCHAR2(100)) physicalDisk
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/size           /text()')                   AS VARCHAR2(100)) disk_size
-      , CAST(EXTRACTVALUE(VALUE(v), '/celldisk/status         /text()')                   AS VARCHAR2(100)) status
-    FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/celldisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
-        c.conftype = 'CELLDISKS'
-),
- gd AS (
-    SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/name/text()')                               AS VARCHAR2(100)) name
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmDiskgroupName/text()')                   AS VARCHAR2(100)) asmDiskgroupName 
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmDiskName     /text()')                   AS VARCHAR2(100)) asmDiskName
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/asmFailGroupName/text()')                   AS VARCHAR2(100)) asmFailGroupName
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/availableTo     /text()')                   AS VARCHAR2(100)) availableTo
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/cachingPolicy   /text()')                   AS VARCHAR2(100)) cachingPolicy
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/cellDisk        /text()')                   AS VARCHAR2(100)) cellDisk
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/comment         /text()')                   AS VARCHAR2(100)) disk_comment
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/creationTime    /text()')                   AS VARCHAR2(100)) creationTime
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/diskType        /text()')                   AS VARCHAR2(100)) diskType
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/errorCount      /text()')                   AS VARCHAR2(100)) errorCount
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/id              /text()')                   AS VARCHAR2(100)) id
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/offset          /text()')                   AS VARCHAR2(100)) offset
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/size            /text()')                   AS VARCHAR2(100)) disk_size
-      , CAST(EXTRACTVALUE(VALUE(v), '/griddisk/status          /text()')                   AS VARCHAR2(100)) status
-    FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/griddisk'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
-        c.conftype = 'GRIDDISKS'
-),
- lun AS (
-    SELECT /*+ MATERIALIZE */
-        c.cellname 
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/cellDisk         /text()')              AS VARCHAR2(100)) cellDisk      
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/deviceName       /text()')              AS VARCHAR2(100)) deviceName    
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/diskType         /text()')              AS VARCHAR2(100)) diskType      
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/id               /text()')              AS VARCHAR2(100)) id            
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/isSystemLun      /text()')              AS VARCHAR2(100)) isSystemLun   
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunAutoCreate    /text()')              AS VARCHAR2(100)) lunAutoCreate 
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunSize          /text()')              AS VARCHAR2(100)) lunSize       
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/physicalDrives   /text()')              AS VARCHAR2(100)) physicalDrives
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/raidLevel        /text()')              AS VARCHAR2(100)) raidLevel
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/lunWriteCacheMode/text()')              AS VARCHAR2(100)) lunWriteCacheMode
-      , CAST(EXTRACTVALUE(VALUE(v), '/lun/status           /text()')              AS VARCHAR2(100)) status        
-    FROM
-        &&v_object_prefix.cell_config c
-      , TABLE(XMLSEQUENCE(EXTRACT(XMLTYPE(c.confval), '/cli-output/lun'))) v  -- gv isn't needed, all cells should be visible in all instances
-    WHERE 
-        c.conftype = 'LUNS'
-)
- , ad  AS (SELECT /*+ MATERIALIZE */ * FROM &&v_object_prefix.asm_disk)
- , adg AS (SELECT /*+ MATERIALIZE */ * FROM &&v_object_prefix.asm_diskgroup)
-SELECT 
-    pd.cellname
-  , SUBSTR(lun.deviceName,1,20)     lun_devicename
-  , pd.name physdisk_name
-  , SUBSTR(pd.status,1,20)          physdisk_status
-  , cd.name celldisk_name
-  , SUBSTR(cd.devicepartition,1,20) cd_devicepart
-  , gd.name griddisk_name
-  , ad.name  asm_disk
-  , adg.name asm_diskgroup
-  , lun.lunWriteCacheMode
---  , SUBSTR(cd.devicename,1,20)      cd_devicename
---  , SUBSTR(lun.devicename,1,20)     lun_devicename
-FROM
-    gd
-  , cd
-  , pd
-  , lun
-  , ad
-  , adg
-WHERE
-    ad.group_number = adg.group_number (+)
-AND gd.asmdiskname = ad.name (+)
-AND cd.name = gd.cellDisk (+)
-AND pd.id =   cd.physicalDisk (+)
---AND cd.name = lun.celldisk (+)
-AND cd.lun=lun.ID(+) -- as per Jie Wu
-ORDER BY
-    --disktype
+    asm_diskgroup,
+    cellname,
+    celldisk_name,
+    asm_disk,
+    griddisk_name,
     cellname
-  , celldisk_name
-  , griddisk_name
-  , asm_disk
-  , asm_diskgroup
 ]';
 END;
 /


### PR DESCRIPTION
1 -Cell IORM Status- IORM plan name and status correction for cell version 18, instead of interdatabaseplan they are reported as iormplan.
2 - Cell Disk Topology - Fixed row duplication and changed columns on the join conditions to cell server version 18.
3 - Removed second topology query, seemed redundant.

Tested on both 12 and 18.