### PR TITLE
Delete nonprinting symbol

### DIFF
--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -1,4 +1,4 @@
-﻿DEF edb360_vYYNN = 'v182';
+DEF edb360_vYYNN = 'v182';
 DEF edb360_vrsn = '&&edb360_vYYNN. (2018-09-09)';
 DEF edb360_copyright = ' (c) 2018';
 


### PR DESCRIPTION
Delete nonprinting symbol at the beginning of the first line.
Execution hangs on that place.