### PR TITLE
skip_inst_fix

### DIFF
--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -575,6 +575,35 @@ SELECT NVL2('&&inst1_present.','','-- skip inst1') skip_inst1,
        NVL2('&&inst7_present.','','-- skip inst7') skip_inst7,
        NVL2('&&inst8_present.','','-- skip inst8') skip_inst8
   FROM DUAL;
+
+SET SERVEROUT ON;
+SET SERVEROUT ON SIZE 1000000;
+SET SERVEROUT ON SIZE UNL;
+DEF chart_setup_driver ='&&edb360_output_directory.99800_&&common_edb360_prefix._chart_setup_driver1.sql';
+SPO &&chart_setup_driver.;
+DECLARE
+  l_count NUMBER;
+  l_instances varchar2(15):='&&inst1_present.&&inst2_present.&&inst3_present.&&inst4_present.&&inst5_present.&&inst6_present.&&inst7_present.&&inst8_present.';
+BEGIN
+  FOR i IN 1 .. 8
+  LOOP
+    IF instr(l_instances,to_char(i,'fm9'))=0 THEN
+      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
+      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
+    ELSE
+      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.000 PRI;');
+      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
+    END IF;
+  END LOOP;
+  FOR i IN 9 .. 15 LOOP
+   DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
+   DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';'); 
+  END LOOP
+END;
+/
+SPO OFF;
+SET SERVEROUT OFF;
+
 -- eAdam
 DEF edb360_eadam_snaps = '-666';
 

--- a/sql/edb360_0c_post.sql
+++ b/sql/edb360_0c_post.sql
@@ -18,6 +18,9 @@ ALTER SESSION SET SQL_TRACE = FALSE;
 
 PRO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+-- Collect chart setup driver
+HOS zip -mj &&edb360_zip_filename. &&chart_setup_driver. >> &&edb360_log3..txt
+
 -- cleanup
 SET HEA ON; 
 SET LIN 80; 

--- a/sql/edb360_1a_awr1.sql
+++ b/sql/edb360_1a_awr1.sql
@@ -249,32 +249,7 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@metric_name@', '&&title.');
 DEF skip_lch = 'Y';
 
 PRO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
--- from 5a
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA 'Inst '||i||'' FOR 999990.000 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = 'Inst '||i||'';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF main_table = '&&awr_hist_prefix.ACTIVE_SESS_HISTORY';
 DEF chartype = 'AreaChart';

--- a/sql/edb360_1e_resources.sql
+++ b/sql/edb360_1e_resources.sql
@@ -386,87 +386,68 @@ END;
 DEF vbaseline = ''; 
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'CPU Demand Series (Peak) for Cluster';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 --DEF vbaseline = 'baseline:&&avg_cpu_count.,';
 DEF vbaseline = '';
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'CPU Demand Series (Peak) for Instance 1';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'CPU Demand Series (Peak) for Instance 2';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'CPU Demand Series (Peak) for Instance 3';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'CPU Demand Series (Peak) for Instance 4';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
-DEF title = 'CPU Demand Series (Peak) for Instance 5';
+EF title = 'CPU Demand Series (Peak) for Instance 5';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
-DEF title = 'CPU Demand Series (Peak) for Instance 6';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
-DEF title = 'CPU Demand Series (Peak) for Instance 7';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'CPU Demand Series (Peak) for Instance 8';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 DEF skip_pch = 'Y';
@@ -562,87 +543,70 @@ END;
 DEF vbaseline = ''; 
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'CPU Demand Series (Percentile) for Cluster';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 --DEF vbaseline = 'baseline:&&avg_cpu_count.,';
 DEF vbaseline = '';
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'CPU Demand Series (Percentile) for Instance 1';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'CPU Demand Series (Percentile) for Instance 2';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'CPU Demand Series (Percentile) for Instance 3';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'CPU Demand Series (Percentile) for Instance 4';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'CPU Demand Series (Percentile) for Instance 5';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'CPU Demand Series (Percentile) for Instance 6';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'CPU Demand Series (Percentile) for Instance 7';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'CPU Demand Series (Percentile) for Instance 8';
 DEF abstract = 'Number of Sessions demanding CPU. Based on percentiles per hour as per Active Session History (ASH).<br />'
 DEF foot = 'Sessions "ON CPU"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 --DEF vbaseline = 'baseline:&&sum_cpu_count.,'; 
 DEF vbaseline = ''; 
@@ -1363,66 +1327,49 @@ SELECT snap_id,
 END;
 /
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Memory Size Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Memory Size Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Memory Size Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Memory Size Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Memory Size Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Memory Size Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Memory Size Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Memory Size Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Memory Size Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -1576,9 +1523,8 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Tablespace Size Series';
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -1972,102 +1918,85 @@ DEF tit_03 = 'W IOPS';
 DEF vaxis = 'IOPS (RW, R and W)';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
 DEF title = 'IOPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'IOPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'IOPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'IOPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'IOPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'IOPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'IOPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'IOPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) I/O Operations per Second (IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'IOPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_iops');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_iops');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'RW MBPS';
 DEF tit_02 = 'R MBPS';
@@ -2075,102 +2004,85 @@ DEF tit_03 = 'W MBPS';
 DEF vaxis = 'MBPS (RW, R and W)';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
 DEF title = 'MBPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'MBPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'MBPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'MBPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'MBPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'MBPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'MBPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'MBPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read (R), Write (W) and Read-Write (RW) Mega Bytes per Second (MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'MBPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@column1@', 'rw_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column2@', 'r_mbps');
 EXEC :sql_text := REPLACE(:sql_text, '@column3@', 'w_mbps');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -2428,75 +2340,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
 DEF title = 'R-IOPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'R-IOPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'R-IOPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'R-IOPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'R-IOPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'R-IOPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'R-IOPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'R-IOPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read I/O Operations per Second (R-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'R-IOPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'Reads';
 DEF tit_02 = 'Direct';
@@ -2532,75 +2427,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Reads per Second.<br />'
 DEF title = 'Reads (per second) Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Reads (per second) Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Reads (per second) Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Reads (per second) Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Reads (per second) Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Reads (per second) Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Reads (per second) Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Reads (per second) Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Reads per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Reads (per second) Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'R-MBPS';
 DEF tit_02 = 'Total MBPS';
@@ -2636,75 +2514,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
 DEF title = 'R-MBPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'R-MBPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'R-MBPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'R-MBPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'R-MBPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'R-MBPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'R-MBPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'R-MBPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Read Megabytes per Second (R-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'R-MBPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'W-IOPS';
 DEF tit_02 = 'Total IO Requests';
@@ -2740,75 +2601,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
 DEF title = 'W-IOPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'W-IOPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'W-IOPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'W-IOPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'W-IOPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'W-IOPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'W-IOPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'W-IOPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write I/O Operations per Second (W-IOPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'W-IOPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'Writes';
 DEF tit_02 = 'Direct';
@@ -2844,75 +2688,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Writes per Second.<br />'
 DEF title = 'Writes (per second) Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Writes (per second) Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Writes (per second) Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Writes (per second) Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Writes (per second) Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Writes (per second) Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Writes (per second) Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Writes (per second) Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Writes per Second.<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Writes (per second) Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF tit_01 = 'W-MBPS';
 DEF tit_02 = 'Total MBPS';
@@ -2948,75 +2775,58 @@ EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column14#', '0 dummy_14,'
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup2, '#column15#', '0 dummy_15');
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
 DEF title = 'W-MBPS Series for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'W-MBPS Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'W-MBPS Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'W-MBPS Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'W-MBPS Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'W-MBPS Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'W-MBPS Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'W-MBPS Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
 DEF abstract = 'Write Megabytes per Second (W-MBPS).<br />'
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'W-MBPS Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_3b_plan_stability.sql
+++ b/sql/edb360_3b_plan_stability.sql
@@ -197,9 +197,8 @@ BEGIN
   :sql_text := q'[
 SELECT *
   FROM &&dva_object_prefix.sql_plan_dir_objects
- ORDER BY
-       1,2,3,4
- ]';
+ ORDER BY 1,2,3,4
+]';
 END;
 /
 @@&&skip_10g_script.&&skip_11g_script.edb360_9a_pre_one.sql       

--- a/sql/edb360_3e_os_stats.sql
+++ b/sql/edb360_3e_os_stats.sql
@@ -107,66 +107,50 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'OS Load and CPU Cores for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'OS Load and CPU Cores for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'OS Load and CPU Cores for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'OS Load and CPU Cores for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'OS Load and CPU Cores for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'OS Load and CPU Cores for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'OS Load and CPU Cores for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'OS Load and CPU Cores for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'OS Load and CPU Cores for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF main_table = '&&awr_hist_prefix.OSSTAT';
@@ -258,66 +242,50 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'OS Load and CPU Subscription Threshold for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'OS Load and CPU Subscription Threshold for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF main_table = '&&awr_hist_prefix.OSSTAT';
@@ -419,66 +387,50 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'CPU Time Percent for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'CPU Time Percent for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'CPU Time Percent for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'CPU Time Percent for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'CPU Time Percent for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'CPU Time Percent for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'CPU Time Percent for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'CPU Time Percent for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'CPU Time Percent for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF tit_01 = 'Busy Time %';
@@ -566,84 +518,68 @@ COL cores_over_threads NEW_V cores_over_threads;
 DEF abstract = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'CPU Busy and Idle Times Percent for Cluster';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&gv_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS');
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 1';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 1 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 2';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 2 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 3';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 3 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 4';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 4 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 5';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 5 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 6';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 6 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 7';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 7 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'CPU Busy and Idle Times Percent for Instance 8';
 SELECT TO_CHAR(ROUND(100 * SUM(CASE stat_name WHEN 'NUM_CPU_CORES' THEN value ELSE 0 END)/SUM(CASE stat_name WHEN 'NUM_CPUS' THEN value ELSE 0 END))) cores_over_threads FROM &&awr_object_prefix.osstat WHERE stat_name IN ('NUM_CPU_CORES', 'NUM_CPUS') AND instance_number = 8 AND snap_id = &&maximum_snap_id.;
 DEF abstract = 'CPU Cores threshold is at &&cores_over_threads.% mark.<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF tit_01 = 'User Time %';
@@ -730,66 +666,50 @@ DEF vaxis = 'Percent over (User + Sys)';
 DEF abstract = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'CPU User and Sys Times Percent for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'CPU User and Sys Times Percent for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'CPU User and Sys Times Percent for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'CPU User and Sys Times Percent for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'CPU User and Sys Times Percent for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'CPU User and Sys Times Percent for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'CPU User and Sys Times Percent for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'CPU User and Sys Times Percent for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'CPU User and Sys Times Percent for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF main_table = '&&awr_hist_prefix.OSSTAT';
@@ -879,102 +799,62 @@ END;
 DEF abstract = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'Virtual Memory (VM) for Cluster';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Virtual Memory (VM) for Instance 1';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Virtual Memory (VM) for Instance 2';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Virtual Memory (VM) for Instance 3';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Virtual Memory (VM) for Instance 4';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Virtual Memory (VM) for Instance 5';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Virtual Memory (VM) for Instance 6';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Virtual Memory (VM) for Instance 7';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Virtual Memory (VM) for Instance 8';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99810_&&common_edb360_prefix._chart_setup_driver1.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99810_&&common_edb360_prefix._chart_setup_driver1.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99810_&&common_edb360_prefix._chart_setup_driver1.sql >> &&edb360_log3..txt
-
+@&&chart_setup_driver;
 
 DEF main_table = '&&awr_hist_prefix.OSSTAT';
 DEF chartype = 'LineChart';

--- a/sql/edb360_3f_ic_latency.sql
+++ b/sql/edb360_3f_ic_latency.sql
@@ -273,30 +273,7 @@ SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
 END;
 /
 
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99800_&&common_edb360_prefix._chart_setup_driver2.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 13
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i + 2, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.0 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i + 2, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99800_&&common_edb360_prefix._chart_setup_driver2.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99800_&&common_edb360_prefix._chart_setup_driver2.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF tit_01 = 'Cluster Avg';
 DEF tit_02 = '';
@@ -332,299 +309,235 @@ EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
 DEF tit_02 = 'Inst Avg';
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = '8K msg pings received from Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = '8K msg pings sent to Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = '500B msg pings received from Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = '500B msg pings sent to Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = '8K msg pings received from Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = '8K msg pings sent to Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = '500B msg pings received from Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = '500B msg pings sent to Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = '8K msg pings received from Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = '8K msg pings sent to Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = '500B msg pings received from Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = '500B msg pings sent to Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = '8K msg pings received from Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = '8K msg pings sent to Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = '500B msg pings received from Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = '500B msg pings sent to Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = '8K msg pings received from Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = '8K msg pings sent to Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = '500B msg pings received from Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = '500B msg pings sent to Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = '8K msg pings received from Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = '8K msg pings sent to Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = '500B msg pings received from Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = '500B msg pings sent to Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = '8K msg pings received from Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = '8K msg pings sent to Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = '500B msg pings received from Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = '500B msg pings sent to Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = '8K msg pings received from Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = '8K msg pings sent to Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '8K');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = '500B msg pings received from Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'target');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = '500B msg pings sent to Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 EXEC :sql_text := REPLACE(:sql_text, '@msg@', '500B');
 EXEC :sql_text := REPLACE(:sql_text, '@denorm@', 'source');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 

--- a/sql/edb360_3g_ic_performance.sql
+++ b/sql/edb360_3g_ic_performance.sql
@@ -103,60 +103,44 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'h.instance_num
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Interconnect Client Statistics for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Interconnect Client Statistics for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Interconnect Client Statistics for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Interconnect Client Statistics for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Interconnect Client Statistics for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Interconnect Client Statistics for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Interconnect Client Statistics for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Interconnect Client Statistics for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 /****************************************************************************************/
 
@@ -317,60 +301,44 @@ EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', 'h.instance_nu
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'IC Device Statistics summary for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'IC Device Statistics summary for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'IC Device Statistics summary for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'IC Device Statistics summary for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'IC Device Statistics summary for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'IC Device Statistics summary for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'IC Device Statistics summary for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'IC Device Statistics summary for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -409,53 +377,37 @@ SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
 ]';
 END;
 /
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'IC Device Statistics details for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'IC Device Statistics details for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'IC Device Statistics details for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'IC Device Statistics details for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'IC Device Statistics details for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'IC Device Statistics details for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'IC Device Statistics details for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'IC Device Statistics details for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 SPO &&edb360_main_report..html APP;
 PRO </ol>

--- a/sql/edb360_3h_sessions.sql
+++ b/sql/edb360_3h_sessions.sql
@@ -1137,65 +1137,48 @@ DEF tit_12 = '';
 DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
-DEF skip_all = '&&is_single_instance.';
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@resource_name@', 'processes');
 EXEC :sql_text := REPLACE(:sql_text_backup2, '''@instance_number@''', 'r.instance_number');
-@@&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Processes Time Series for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Processes Time Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Processes Time Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Processes Time Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Processes Time Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Processes Time Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Processes Time Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Processes Time Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 DEF chartype = 'LineChart';
@@ -1220,66 +1203,50 @@ DEF tit_12 = '';
 DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
-DEF skip_all = '&&is_single_instance.';
 EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@resource_name@', 'sessions');
 EXEC :sql_text := REPLACE(:sql_text_backup2, '''@instance_number@''', 'r.instance_number');
-@@&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Sessions Time Series for Instance 1';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Sessions Time Series for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Sessions Time Series for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Sessions Time Series for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Sessions Time Series for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Sessions Time Series for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Sessions Time Series for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Sessions Time Series for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup2, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
 SPO &&edb360_main_report..html APP;

--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -127,12 +127,11 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'SGA Statistics for Cluster';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = 'SGA Statistics for Instance 1';

--- a/sql/edb360_4b_pga_stats.sql
+++ b/sql/edb360_4b_pga_stats.sql
@@ -169,74 +169,57 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'PGA Statistics for Cluster';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'PGA Statistics for Instance 1';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'PGA Statistics for Instance 2';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'PGA Statistics for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'PGA Statistics for Instance 4';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'PGA Statistics for Instance 5';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'PGA Statistics for Instance 6';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'PGA Statistics for Instance 7';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'PGA Statistics for Instance 8';
 DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 SPO &&edb360_main_report..html APP;
 PRO </ol>

--- a/sql/edb360_4c_mem_stats.sql
+++ b/sql/edb360_4c_mem_stats.sql
@@ -142,84 +142,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Memory Statistics for Cluster';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'h1.instance_number');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'Memory Statistics for Instance 1';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'Memory Statistics for Instance 2';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'Memory Statistics for Instance 3';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'Memory Statistics for Instance 4';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'Memory Statistics for Instance 5';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'Memory Statistics for Instance 6';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'Memory Statistics for Instance 7';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'Memory Statistics for Instance 8';
 DEF abstract = '&&abstract_uom.';
 DEF foot = 'Includes Free SGA Memory Available.'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 SPO &&edb360_main_report..html APP;
 PRO </ol>

--- a/sql/edb360_4d_time_model.sql
+++ b/sql/edb360_4d_time_model.sql
@@ -188,75 +188,58 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'System Time Model (STM) per Cluster';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'System Time Model (STM) for Instance 1';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'System Time Model (STM) for Instance 2';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'System Time Model (STM) for Instance 3';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'System Time Model (STM) for Instance 4';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'System Time Model (STM) for Instance 5';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'System Time Model (STM) for Instance 6';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'System Time Model (STM) for Instance 7';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'System Time Model (STM) for Instance 8';
 DEF abstract = 'Average Active Sessions (AAS).<br />'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 SPO &&edb360_main_report..html APP;
 PRO </ol>

--- a/sql/edb360_4e_time_model_comp.sql
+++ b/sql/edb360_4e_time_model_comp.sql
@@ -7,30 +7,7 @@ PRO <h2>&&section_id.. &&section_name.</h2>
 PRO <ol start="&&report_sequence.">
 SPO OFF;
 
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99850_&&common_edb360_prefix._chart_setup_driver3.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.000 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99850_&&common_edb360_prefix._chart_setup_driver3.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99850_&&common_edb360_prefix._chart_setup_driver3.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 BEGIN
   :sql_text_backup := q'[

--- a/sql/edb360_4f_io_waits.sql
+++ b/sql/edb360_4f_io_waits.sql
@@ -58,31 +58,7 @@ END;
 /
 @@edb360_9a_pre_one.sql
 
-
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99870_&&common_edb360_prefix._chart_setup_driver4.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999999999999990 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99870_&&common_edb360_prefix._chart_setup_driver4.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99870_&&common_edb360_prefix._chart_setup_driver4.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
 DEF vaxis = 'Wait Minutes (stacked)';
@@ -161,85 +137,73 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'User I/O Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''User I/O''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'System I/O Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''System I/O''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Cluster Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Cluster''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Commit Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Commit''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Concurrency Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Concurrency''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Application Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Application''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Administrative Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Administrative''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Configuration Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Configuration''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Network Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Network''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Queueing Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Queueing''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Scheduler Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Scheduler''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
+DEF skip_all = '';
 DEF title = 'Other Wait Time per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Other''');
 @@&&skip_all.&&skip_diagnostics.edb360_9a_pre_one.sql

--- a/sql/edb360_5a_ash.sql
+++ b/sql/edb360_5a_ash.sql
@@ -97,66 +97,49 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'AAS per Wait Class for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'AAS per Wait Class for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'AAS per Wait Class for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'AAS per Wait Class for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'AAS per Wait Class for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'AAS per Wait Class for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'AAS per Wait Class for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'AAS per Wait Class for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'AAS per Wait Class for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 DEF series_01 = '';
 DEF series_02 = '';
@@ -174,30 +157,7 @@ DEF series_13 = '';
 DEF series_14 = '';
 DEF series_15 = '';
 
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99820_&&common_edb360_prefix._chart_setup_driver2.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.000 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99820_&&common_edb360_prefix._chart_setup_driver2.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99820_&&common_edb360_prefix._chart_setup_driver2.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF main_table = '&&awr_hist_prefix.ACTIVE_SESS_HISTORY';
 DEF vaxis = 'Average Active Sessions - AAS (stacked)';

--- a/sql/edb360_5b_ash_wait.sql
+++ b/sql/edb360_5b_ash_wait.sql
@@ -7,31 +7,7 @@ PRO <h2>&&section_id.. &&section_name.</h2>
 PRO <ol start="&&report_sequence.">
 SPO OFF;
 
--- from 5a
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99830_&&common_edb360_prefix._chart_setup_driver2.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.000 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99830_&&common_edb360_prefix._chart_setup_driver2.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99830_&&common_edb360_prefix._chart_setup_driver2.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF main_table = '&&awr_hist_prefix.ACTIVE_SESS_HISTORY';
 DEF chartype = 'AreaChart';

--- a/sql/edb360_5c_ash_top.sql
+++ b/sql/edb360_5c_ash_top.sql
@@ -7,31 +7,7 @@ PRO <h2>&&section_id.. &&section_name.</h2>
 PRO <ol start="&&report_sequence.">
 SPO OFF;
 
--- from 5a
-SET SERVEROUT ON;
-SET SERVEROUT ON SIZE 1000000;
-SET SERVEROUT ON SIZE UNL;
-SPO &&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql;
-DECLARE
-  l_count NUMBER;
-BEGIN
-  FOR i IN 1 .. 15
-  LOOP
-    SELECT COUNT(*) INTO l_count FROM &&gv_object_prefix.instance WHERE instance_number = i;
-    IF l_count = 0 THEN
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';');
-    ELSE
-      DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' HEA ''Inst '||i||''' FOR 999990.000 PRI;');
-      DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = ''Inst '||i||''';');
-    END IF;
-  END LOOP;
-END;
-/
-SPO OFF;
-SET SERVEROUT OFF;
-@&&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql;
-HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.99840_&&common_edb360_prefix._chart_setup_driver2.sql >> &&edb360_log3..txt
+@&&chart_setup_driver.;
 
 DEF main_table = '&&awr_hist_prefix.ACTIVE_SESS_HISTORY';
 DEF chartype = 'AreaChart';

--- a/sql/edb360_6a_ash_class.sql
+++ b/sql/edb360_6a_ash_class.sql
@@ -52,60 +52,44 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all 
 @@&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 1');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 2');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 3');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 4');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 5');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 6');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 7');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 8');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -150,375 +134,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Classes for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Classes for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Classes for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Classes for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Classes for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Classes for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Classes for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Classes for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Classes for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Classes for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Classes for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Classes for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Classes for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6b_ash_event.sql
+++ b/sql/edb360_6b_ash_event.sql
@@ -52,63 +52,47 @@ DEF title = 'ASH Top Timed Events for Cluster from MEM';
 DEF vaxis = 'Percent of total DB Time';
 DEF haxis = 'Timed Event';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all instances */');
-@@&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 1');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 2');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 3');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 4');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 5');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 6');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 7');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 8');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -155,375 +139,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Events for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Events for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Events for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Events for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_bch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Timed Events for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Timed Events for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Timed Events for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Timed Events for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Timed Events for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Timed Events for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Timed Events for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Timed Events for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_bch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Timed Events for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6c_ash_sql.sql
+++ b/sql/edb360_6c_ash_sql.sql
@@ -56,63 +56,47 @@ END;
 DEF skip_pch = '';
 DEF title = 'ASH Top SQL for Cluster from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all instances */');
-@@&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 1;
 DEF title = 'ASH Top SQL for Instance 1 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 1');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst1.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 2;
 DEF title = 'ASH Top SQL for Instance 2 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 2');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst2.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 3;
 DEF title = 'ASH Top SQL for Instance 3 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 3');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst3.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 4;
 DEF title = 'ASH Top SQL for Instance 4 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 4');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst4.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 5;
 DEF title = 'ASH Top SQL for Instance 5 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 5');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst5.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 6;
 DEF title = 'ASH Top SQL for Instance 6 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 6');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst6.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 7;
 DEF title = 'ASH Top SQL for Instance 7 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 7');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst7.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE inst_id = 8;
 DEF title = 'ASH Top SQL for Instance 8 from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 8');
-@@&&skip_all.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&skip_inst8.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -170,375 +154,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6d_ash_sql_ts.sql
+++ b/sql/edb360_6d_ash_sql_ts.sql
@@ -67,107 +67,91 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6d_ash_sql_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 1 day';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -176,107 +160,91 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6d_ash_sql_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 5 working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -285,107 +253,91 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6d_ash_sql_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for 7 days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -394,107 +346,91 @@ SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360
 DEF filter_predicate = 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6d_ash_sql_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -503,107 +439,91 @@ SELECT '&&between_dates.' between_times FROM DUAL;
 DEF filter_predicate = '1 = 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
 
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top SQL for Cluster for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6d_ash_sql_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top SQL for Instance 1 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top SQL for Instance 2 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top SQL for Instance 3 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top SQL for Instance 4 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top SQL for Instance 5 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top SQL for Instance 6 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top SQL for Instance 7 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top SQL for Instance 8 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6d_ash_sql_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6d_ash_sql_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6e_ash_programs.sql
+++ b/sql/edb360_6e_ash_programs.sql
@@ -53,375 +53,295 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top Programs for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Programs for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Programs for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Programs for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Programs for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Programs for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Programs for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Programs for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Programs for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top Programs for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Programs for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Programs for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Programs for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Programs for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Programs for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Programs for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Programs for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Programs for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top Programs for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Programs for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Programs for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Programs for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Programs for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Programs for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Programs for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Programs for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Programs for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top Programs for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Programs for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Programs for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Programs for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Programs for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Programs for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Programs for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Programs for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Programs for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
+DEF skip_inst = '&&is_single_instance.';
 DEF title = 'ASH Top Programs for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Programs for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Programs for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Programs for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Programs for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Programs for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Programs for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Programs for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Programs for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6g_ash_users.sql
+++ b/sql/edb360_6g_ash_users.sql
@@ -55,225 +55,174 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Users for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Users for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Users for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Users for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Users for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Users for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Users for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Users for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Users for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Users for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Users for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Users for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Users for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Users for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Users for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Users for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Users for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Users for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Users for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Users for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Users for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Users for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Users for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Users for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Users for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Users for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Users for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 
 /*****************************************************************************************/
@@ -281,150 +230,116 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_numb
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Users for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Users for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Users for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Users for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Users for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Users for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Users for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Users for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Users for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Users for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Users for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Users for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Users for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Users for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Users for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Users for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Users for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Users for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6h_ash_plsql.sql
+++ b/sql/edb360_6h_ash_plsql.sql
@@ -76,225 +76,174 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PLSQL Procedures for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PLSQL Procedures for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PLSQL Procedures for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PLSQL Procedures for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PLSQL Procedures for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PLSQL Procedures for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PLSQL Procedures for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PLSQL Procedures for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PLSQL Procedures for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PLSQL Procedures for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PLSQL Procedures for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PLSQL Procedures for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PLSQL Procedures for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PLSQL Procedures for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PLSQL Procedures for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PLSQL Procedures for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PLSQL Procedures for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PLSQL Procedures for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PLSQL Procedures for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PLSQL Procedures for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PLSQL Procedures for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PLSQL Procedures for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PLSQL Procedures for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PLSQL Procedures for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PLSQL Procedures for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PLSQL Procedures for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PLSQL Procedures for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 
 /*****************************************************************************************/
@@ -302,150 +251,116 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_numb
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PLSQL Procedures for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PLSQL Procedures for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PLSQL Procedures for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PLSQL Procedures for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PLSQL Procedures for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PLSQL Procedures for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PLSQL Procedures for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PLSQL Procedures for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PLSQL Procedures for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PLSQL Procedures for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PLSQL Procedures for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PLSQL Procedures for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PLSQL Procedures for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PLSQL Procedures for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PLSQL Procedures for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PLSQL Procedures for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PLSQL Procedures for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PLSQL Procedures for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6i_ash_objects.sql
+++ b/sql/edb360_6i_ash_objects.sql
@@ -60,225 +60,174 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Data Objects for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Data Objects for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Data Objects for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Data Objects for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Data Objects for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Data Objects for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Data Objects for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Data Objects for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Data Objects for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Data Objects for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Data Objects for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Data Objects for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Data Objects for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Data Objects for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Data Objects for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Data Objects for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Data Objects for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Data Objects for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Data Objects for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Data Objects for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Data Objects for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Data Objects for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Data Objects for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Data Objects for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Data Objects for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Data Objects for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Data Objects for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 
 /*****************************************************************************************/
@@ -286,150 +235,116 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_numb
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Data Objects for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Data Objects for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Data Objects for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Data Objects for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Data Objects for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Data Objects for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Data Objects for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Data Objects for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Data Objects for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Data Objects for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Data Objects for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Data Objects for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Data Objects for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Data Objects for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Data Objects for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Data Objects for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Data Objects for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Data Objects for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6j_ash_services.sql
+++ b/sql/edb360_6j_ash_services.sql
@@ -61,225 +61,174 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Services and Users for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Services and Users for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Services and Users for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Services and Users for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Services and Users for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Services and Users for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Services and Users for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Services and Users for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Services and Users for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Services and Users for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Services and Users for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Services and Users for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Services and Users for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Services and Users for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Services and Users for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Services and Users for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Services and Users for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Services and Users for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Services and Users for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Services and Users for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Services and Users for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Services and Users for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Services and Users for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Services and Users for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Services and Users for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Services and Users for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Services and Users for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 
 /*****************************************************************************************/
@@ -287,150 +236,116 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_numb
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Services and Users for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Services and Users for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Services and Users for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Services and Users for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Services and Users for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Services and Users for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Services and Users for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Services and Users for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Services and Users for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top Services and Users for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top Services and Users for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top Services and Users for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top Services and Users for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top Services and Users for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top Services and Users for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top Services and Users for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top Services and Users for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top Services and Users for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6k_ash_phv.sql
+++ b/sql/edb360_6k_ash_phv.sql
@@ -58,7 +58,7 @@ END;
 DEF skip_pch = '';
 DEF title = 'ASH Top PHV for Cluster from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all instances */');
-@@&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
 DEF skip_all = 'Y';
@@ -174,375 +174,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PHV for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PHV for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PHV for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PHV for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PHV for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PHV for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PHV for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PHV for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PHV for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PHV for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PHV for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PHV for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PHV for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PHV for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PHV for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PHV for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PHV for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PHV for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PHV for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PHV for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PHV for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PHV for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PHV for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PHV for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PHV for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PHV for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PHV for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PHV for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PHV for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PHV for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PHV for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PHV for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PHV for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PHV for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PHV for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PHV for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PHV for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PHV for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PHV for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PHV for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PHV for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PHV for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PHV for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PHV for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PHV for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6l_ash_signature.sql
+++ b/sql/edb360_6l_ash_signature.sql
@@ -64,7 +64,7 @@ END;
 DEF skip_pch = '';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster from MEM';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all instances */');
-@@&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
+@@&&is_single_instance.&&edb360_skip_ash_mem.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
 DEF skip_all = 'Y';
@@ -185,375 +185,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top FORCE_MATCHING_SIGNATURE for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6m_ash_pdbs.sql
+++ b/sql/edb360_6m_ash_pdbs.sql
@@ -56,375 +56,290 @@ END;
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 1, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 1 day';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS')||', and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 5 working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS') - 7, 'YYYY-MM-DD HH24:MM:SS')||' and '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS'), 'YYYY-MM-DD HH24:MM:SS') between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 7 days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360_conf_work_time_to. hours' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for &&hist_work_days. working days';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
 SELECT '&&between_dates.' between_times FROM DUAL;
 
 DEF skip_pch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_pch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for &&history_days. days of history';
 DEF title_suffix = '&&between_times.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/edb360_6n_ash_pdbs_ts.sql
+++ b/sql/edb360_6n_ash_pdbs_ts.sql
@@ -53,107 +53,90 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 1 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 1 day';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -162,107 +145,90 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 5 working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -271,107 +237,90 @@ SELECT ', between '||TO_CHAR(TO_TIMESTAMP('&&tool_sysdate.', 'YYYYMMDDHH24MISS')
 DEF filter_predicate = 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND sample_time BETWEEN TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'') - 7 AND TO_TIMESTAMP(''&&tool_sysdate.'', ''YYYYMMDDHH24MISS'')');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for 7 days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -380,107 +329,90 @@ SELECT '&&between_dates., and between &&edb360_conf_work_time_from. and &&edb360
 DEF filter_predicate = 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8 AND TO_CHAR(sample_time, ''D'') BETWEEN ''&&edb360_conf_work_day_from.'' AND ''&&edb360_conf_work_day_to.'' AND TO_CHAR(sample_time, ''HH24'') BETWEEN ''&&edb360_conf_work_time_from.'' AND ''&&edb360_conf_work_time_to.''');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for &&hist_work_days. working days';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 
@@ -489,107 +421,90 @@ SELECT '&&between_dates.' between_times FROM DUAL;
 DEF filter_predicate = '1 = 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1');
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'ASH Top PDBs for Cluster for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&is_single_instance.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&is_single_instance.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 1');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 1;
 DEF title = 'ASH Top PDBs for Instance 1 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst1.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst1.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 2');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 2;
 DEF title = 'ASH Top PDBs for Instance 2 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst2.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst2.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 3');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 3;
 DEF title = 'ASH Top PDBs for Instance 3 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst3.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst3.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 4');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 4;
 DEF title = 'ASH Top PDBs for Instance 4 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst4.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst4.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 5');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 5;
 DEF title = 'ASH Top PDBs for Instance 5 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst5.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst5.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 6');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 6;
 DEF title = 'ASH Top PDBs for Instance 6 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst6.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst6.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 7');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 7;
 DEF title = 'ASH Top PDBs for Instance 7 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst7.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst7.edb360_9a_pre_one.sql
 
 --
 
 DEF filter_predicate = 'instance_number = 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'instance_number = 8');
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM &&gv_object_prefix.instance WHERE instance_number = 8;
 DEF title = 'ASH Top PDBs for Instance 8 for &&history_days. days of history';
 
-@@&&skip_all.edb360_6n_ash_pdbs_ts_aux.sql
-@@&&skip_all.edb360_9a_pre_one.sql
+@@&&skip_inst8.edb360_6n_ash_pdbs_ts_aux.sql
+@@&&skip_inst8.edb360_9a_pre_one.sql
 
 /*****************************************************************************************/
 

--- a/sql/gather_stats_wr_sys.sql
+++ b/sql/gather_stats_wr_sys.sql
@@ -18,7 +18,7 @@
 --             
 ---------------------------------------------------------------------------------------
 --
-SET HEA OFF PAGES 0;
+SET HEA OFF LINES 500 PAGES 0;
 SPO gather_stats_awr.sql;
 SELECT 'EXEC DBMS_STATS.GATHER_TABLE_STATS(''SYS'','''||table_name||''',force=>TRUE);'
   FROM dba_tables
@@ -28,6 +28,6 @@ SELECT 'EXEC DBMS_STATS.GATHER_TABLE_STATS(''SYS'','''||table_name||''',force=>T
        table_name
 /
 SPO OFF;
-SET HEA ON PAGES 24;
+SET HEA ON LINES 80 PAGES 24;
 SET ECHO ON;
 @gather_stats_awr.sql

--- a/sql/sqld360_0b_pre.sql
+++ b/sql/sqld360_0b_pre.sql
@@ -246,10 +246,6 @@ SELECT ROUND(AVG(TO_NUMBER(value))) avg_cpu_count FROM gv$system_parameter2 WHER
 COL sum_cpu_count NEW_V sum_cpu_count FOR A3;
 SELECT SUM(TO_NUMBER(value)) sum_cpu_count FROM gv$system_parameter2 WHERE name = 'cpu_count';
 
--- determine if rac or single instance (null means rac)
-COL is_single_instance NEW_V is_single_instance FOR A1;
-SELECT CASE COUNT(*) WHEN 1 THEN 'Y' END is_single_instance FROM gv$instance;
-
 -- timestamp on filename
 COL sqld360_file_time NEW_V sqld360_file_time FOR A20;
 SELECT TO_CHAR(SYSDATE, 'YYYYMMDD_HH24MI') sqld360_file_time FROM DUAL;
@@ -281,6 +277,54 @@ SELECT TO_NUMBER(TRUNC(VALUE/1000,3)) sqld360_ashsample FROM v$parameter2 WHERE 
 -- Formula is really simple, adjust the _ash_sampling_interval to seconds and multiply by _ash_disk_filter_ratio
 COL sqld360_ashtimevalue NEW_V sqld360_ashtimevalue
 SELECT TO_NUMBER(TRUNC(&&sqld360_ashsample.*&&sqld360_ashdiskfilter.,3)) sqld360_ashtimevalue FROM DUAL;
+
+-- Determine if rac or single instance (null means rac)
+-- and which instances were present in the history (null means instance not present).
+
+COL inst1_present NEW_V inst1_present FOR A1;
+COL inst2_present NEW_V inst2_present FOR A1;
+COL inst3_present NEW_V inst3_present FOR A1;
+COL inst4_present NEW_V inst4_present FOR A1;
+COL inst5_present NEW_V inst5_present FOR A1;
+COL inst6_present NEW_V inst6_present FOR A1;
+COL inst7_present NEW_V inst7_present FOR A1;
+COL inst8_present NEW_V inst8_present FOR A1;
+COL skip_inst1 NEW_V skip_inst1;
+COL skip_inst2 NEW_V skip_inst2;
+COL skip_inst3 NEW_V skip_inst3;
+COL skip_inst4 NEW_V skip_inst4;
+COL skip_inst5 NEW_V skip_inst5;
+COL skip_inst6 NEW_V skip_inst6;
+COL skip_inst7 NEW_V skip_inst7;
+COL skip_inst8 NEW_V skip_inst8;
+COL is_single_instance NEW_V is_single_instance FOR A1;
+
+WITH hist AS (
+SELECT DISTINCT instance_number
+  FROM &&awr_object_prefix.snapshot
+WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+   AND dbid = &&edb360_dbid.
+)
+SELECT MAX(CASE instance_number WHEN 1 THEN '1' ELSE NULL END) inst1_present,
+       MAX(CASE instance_number WHEN 2 THEN '2' ELSE NULL END) inst2_present,
+       MAX(CASE instance_number WHEN 3 THEN '3' ELSE NULL END) inst3_present,
+       MAX(CASE instance_number WHEN 4 THEN '4' ELSE NULL END) inst4_present,
+       MAX(CASE instance_number WHEN 5 THEN '5' ELSE NULL END) inst5_present,
+       MAX(CASE instance_number WHEN 6 THEN '6' ELSE NULL END) inst6_present,
+       MAX(CASE instance_number WHEN 7 THEN '7' ELSE NULL END) inst7_present,
+       MAX(CASE instance_number WHEN 8 THEN '8' ELSE NULL END) inst8_present,     
+       (CASE COUNT(instance_number) WHEN 1 THEN 'Y' ELSE NULL END) is_single_instance
+  FROM hist;
+
+SELECT NVL2('&&inst1_present.','','-- skip inst1') skip_inst1,
+       NVL2('&&inst2_present.','','-- skip inst2') skip_inst2,
+       NVL2('&&inst3_present.','','-- skip inst3') skip_inst3,
+       NVL2('&&inst4_present.','','-- skip inst4') skip_inst4,
+       NVL2('&&inst5_present.','','-- skip inst5') skip_inst5,
+       NVL2('&&inst6_present.','','-- skip inst6') skip_inst6,
+       NVL2('&&inst7_present.','','-- skip inst7') skip_inst7,
+       NVL2('&&inst8_present.','','-- skip inst8') skip_inst8
+  FROM DUAL;
 
 -- ebs
 DEF ebs_release = '';

--- a/sql/sqld360_4a_system_impact.sql
+++ b/sql/sqld360_4a_system_impact.sql
@@ -86,84 +86,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'SQL Execute Time for Cluster';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'SQL Execute Time for Instance 1';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'SQL Execute Time for Instance 2';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'SQL Execute Time for Instance 3';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'SQL Execute Time for Instance 4';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'SQL Execute Time for Instance 5';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'SQL Execute Time for Instance 6';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'SQL Execute Time for Instance 7';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'SQL Execute Time for Instance 8';
 DEF abstract = 'SQL Execute Time for SQL ID &&sqld360_sqlid. compared to the total System SQL Execute Time'
 DEF foot = 'SQL Execute Elapsed Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -234,66 +217,49 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Peak Demand for recent executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Peak Demand for recent executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Peak Demand for recent executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Peak Demand for recent executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Peak Demand for recent executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Peak Demand for recent executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Peak Demand for recent executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Peak Demand for recent executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Peak Demand for recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 ------------------------------
@@ -367,66 +333,49 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Peak Demand for historical executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Peak Demand for historical executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Peak Demand for historical executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Peak Demand for historical executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Peak Demand for historical executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Peak Demand for historical executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Peak Demand for historical executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Peak Demand for historical executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Peak Demand for historical executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -495,66 +444,49 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Distinct number of sessions executing for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Distinct number of sessions executing for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Distinct number of sessions executing for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Distinct number of sessions executing for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Distinct number of sessions executing for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Distinct number of sessions executing for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Distinct number of sessions executing for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Distinct number of sessions executing for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Distinct number of sessions executing for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -625,84 +557,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total Buffer Gets for Cluster';
 DEF abstract = 'Buffer gets and disk reads for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total Buffer Gets for Instance 1';
 DEF abstract = 'Buffer gets and disk reads for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total Buffer Gets for Instance 2';
 DEF abstract = 'Buffer gets and disk reads for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total Buffer Gets for Instance 3';
 DEF abstract = 'Buffer gets and disk reads for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total Buffer Gets for Instance 4';
 DEF abstract = 'Buffer gets and disk reads for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total Buffer Gets for Instance 5';
 DEF abstract = 'Buffer gets and disk reads for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total Buffer Gets for Instance 6';
 DEF abstract = 'Buffer gets and disk reads for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total Buffer Gets per Instance 7';
 DEF abstract = 'Buffer gets and disk reads for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total Buffer Gets per Instance 8';
 DEF abstract = 'Buffer gets and disk reads for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -773,84 +688,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total Rows Processed per for Cluster';
 DEF abstract = 'Rows processed and fetch calls for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total Rows Processed per for Instance 1';
 DEF abstract = 'Rows processed and fetch calls for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total Rows Processed per for Instance 2';
 DEF abstract = 'Rows processed and fetch calls for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total Rows Processed per for Instance 3';
 DEF abstract = 'Rows processed and fetch calls for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total Rows Processed per for Instance 4';
 DEF abstract = 'Rows processed and fetch calls for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total Rows Processed per for Instance 5';
 DEF abstract = 'Rows processed and fetch calls for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total Rows Processed per for Instance 6';
 DEF abstract = 'Rows processed and fetch calls for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total Rows Processed per for Instance 7';
 DEF abstract = 'Rows processed and fetch calls for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total Rows Processed per for Instance 8';
 DEF abstract = 'Rows processed and fetch calls for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -922,84 +820,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total number of Executions for Cluster';
 DEF abstract = 'Executions and parse calls for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total number of Executions for Instance 1';
 DEF abstract = 'Executions and parse calls for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total number of Executions for Instance 2';
 DEF abstract = 'Executions and parse calls for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total number of Executions for Instance 3';
 DEF abstract = 'Executions and parse calls for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total number of Executions for Instance 4';
 DEF abstract = 'Executions and parse calls for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total number of Executions for Instance 5';
 DEF abstract = 'Executions and parse calls for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total number of Executions for Instance 6';
 DEF abstract = 'Executions and parse calls for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total number of Executions per Instance 7';
 DEF abstract = 'Executions and parse calls for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total number of Executions per Instance 8';
 DEF abstract = 'Executions and parse calls for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -1072,84 +953,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Version Count and Sharable Memory for Cluster';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Version Count and Sharable Memory for Instance 1';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Version Count and Sharable Memory for Instance 2';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Version Count and Sharable Memory for Instance 3';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Version Count and Sharable Memory for Instance 4';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Version Count and Sharable Memory for Instance 5';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Version Count and Sharable Memory for Instance 6';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Version Count and Sharable Memory for Instance 7';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Version Count and Sharable Memory for Instance 8';
 DEF abstract = 'Number of Child Cursors and Sharable Memory accounted for'
 DEF foot = 'Number of Child Cursors and Sharable Memory accounted for'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 DEF series_01 = ''

--- a/sql/sqld360_4b_execution_metrics.sql
+++ b/sql/sqld360_4b_execution_metrics.sql
@@ -92,84 +92,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'SQL Execute Time by Wait Class for Cluster';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'SQL Execute Time by Wait Class for Instance 1';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'SQL Execute Time by Wait Class for Instance 2';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'SQL Execute Time by Wait Class for Instance 3';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'SQL Execute Time by Wait Class for Instance 4';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'SQL Execute Time by Wait Class for Instance 5';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'SQL Execute Time by Wait Class for Instance 6';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'SQL Execute Time by Wait Class for Instance 7';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'SQL Execute Time by Wait Class for Instance 8';
 DEF abstract = 'SQL Execute Time compared by Wait Class'
 DEF foot = 'Unaccounted Time computed as difference between Elapsed Time and [CPU+IO+App+Clu+Concu] Time'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 DEF series_01 = '';
@@ -241,58 +224,41 @@ SELECT NVL(TO_NUMBER(SUBSTR(partition_stop,INSTR(partition_stop,',',1,3)+1,INSTR
 END;
 /
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Elapsed Time per recent executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Elapsed Time per recent executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Elapsed Time per recent executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Elapsed Time per recent executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Elapsed Time per recent executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Elapsed Time per recent executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Elapsed Time per recent executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Elapsed Time per recent executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Elapsed Time per recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 ------------------------------------------------
 ------------------------------------------------
@@ -356,58 +322,41 @@ SELECT NVL(TO_NUMBER(SUBSTR(partition_stop,INSTR(partition_stop,',',1,3)+1,INSTR
 END;
 /
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Elapsed Time per historical executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Elapsed Time per historical executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Elapsed Time per historical executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Elapsed Time per historical executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Elapsed Time per historical executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Elapsed Time per historical executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Elapsed Time per historical executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Elapsed Time per historical executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Elapsed Time per historical executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 ---------------------
 ---------------------
@@ -476,84 +425,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Buffer Gets/Execution for Cluster';
 DEF abstract = 'Avg Buffer Gets/Execution for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Buffer Gets/Execution for Instance 1';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Buffer Gets/Execution for Instance 2';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Buffer Gets/Execution for Instance 3';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Buffer Gets/Execution for Instance 4';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Buffer Gets/Execution for Instance 5';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Buffer Gets/Execution for Instance 6';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Buffer Gets/Execution for Instance 7';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Buffer Gets/Execution for Instance 8';
 DEF abstract = 'Avg Buffer Gets/Execution for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -625,84 +557,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Rows Processed/Execution for Cluster';
 DEF abstract = 'Avg Rows Processed/Execution for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Rows Processed/Execution for Instance 1';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Rows Processed/Execution for Instance 2';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Rows Processed/Execution for Instance 3';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Rows Processed/Execution for Instance 4';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Rows Processed/Execution for Instance 5';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Rows Processed/Execution for Instance 6';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Rows Processed/Execution for Instance 7';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Rows Processed/Execution for Instance 8';
 DEF abstract = 'Avg Rows Processed/Execution for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -779,84 +694,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution (total) for Cluster';
 DEF abstract = 'Avg Elapsed Time/Execution for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 1';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 2';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 3';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 4';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 5';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 6';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 7';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution (total) for Instance 8';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -932,84 +830,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution (delta) for Cluster';
 DEF abstract = 'Avg Elapsed Time/Execution for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 1';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 2';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 3';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 4';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 5';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 6';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 7';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution (delta) for Instance 8';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -1093,84 +974,67 @@ END;
 /
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Cluster';
 DEF abstract = 'Avg Elapsed Time/Execution for Cluster over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'a.instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 1';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 1 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 2';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 2 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 3';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 3 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 4';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 4 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 5';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 5 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 6';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 6 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 7';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 7 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution (moving 1d) for Instance 8';
 DEF abstract = 'Avg Elapsed Time/Execution for Instance 8 over time from AWR'
 DEF foot = 'Low number of executions or long executing SQL make values less accurate'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = 'Y';
 
@@ -1257,66 +1121,49 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg and Median Elapsed Time/Execution for recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 
 DEF skip_lch = 'Y';
@@ -1419,66 +1266,49 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg and Median Elapsed Time/Execution for historical executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 
 DEF skip_lch = 'Y';
@@ -1513,58 +1343,41 @@ SELECT inst_id, session_id, session_serial#, COUNT(DISTINCT event) num_events, M
 END;
 /
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Streak of non-executing SQL for recent executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 
 -----------------------------------------
@@ -1598,58 +1411,41 @@ SELECT inst_id, session_id, session_serial#, COUNT(DISTINCT event) num_events, M
 END;
 /
 
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Streak of non-executing SQL for historical executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Streak of non-executing SQL for historical executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Streak of non-executing SQL for recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 ---------------------
 ---------------------

--- a/sql/sqld360_4c_execution_metrics_per_phv.sql
+++ b/sql/sqld360_4c_execution_metrics_per_phv.sql
@@ -134,66 +134,49 @@ END;
 / 
 
 DEF skip_bch='';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total number of Executions per PHV for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total number of Executions per PHV for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total number of Executions per PHV for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total number of Executions per PHV for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total number of Executions per PHV for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total number of Executions per PHV for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total number of Executions per PHV for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total number of Executions per PHV for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total number of Executions per PHV for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 
 DEF skip_bch='Y';
@@ -299,66 +282,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Number of execution per PHV from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Number of execution per PHV from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Number of execution per PHV from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Number of execution per PHV from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Number of execution per PHV from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Number of execution per PHV from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Number of execution per PHV from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Number of execution per PHV from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Number of execution per PHV from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -407,66 +373,49 @@ END;
 / 
 
 DEF skip_bch='';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total Elapsed Time for recent executions per PHV for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total Elapsed Time for recent executions per PHV for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='Y';
 ---------------------
@@ -497,66 +446,49 @@ END;
 / 
 
 DEF skip_bch='';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total Elapsed Time for historical executions per PHV for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total Elapsed Time for historical executions per PHV for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_bch='Y';
 ----------------------------
@@ -661,66 +593,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Total Elapsed Time per PHV from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Total Elapsed Time per PHV from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -912,66 +827,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution per PHV for recent executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -1167,66 +1065,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'position');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution per PHV for historical executions for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -1348,66 +1229,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution per PHV (total) from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -1528,66 +1392,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution per PHV (delta) from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -1739,66 +1586,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Elapsed Time/Execution per PHV (moving 1d) from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -1921,66 +1751,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Avg Buffer Gets/Row/Execution per PHV from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI
@@ -2101,66 +1914,49 @@ DEF chartype = 'LineChart';
 DEF stacked = '';
 
 DEF skip_lch = '';
-DEF skip_all = '&&is_single_instance.';
 DEF title = 'Execution Plan Cost per PHV from AWR for Cluster';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&is_single_instance.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 1;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 1';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '1');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst1.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 2;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 2';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '2');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst2.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 3;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 3';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '3');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst3.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 4;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 4';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst4.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 5;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 5';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst5.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 6;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 6';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst6.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 7;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 7';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst7.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF skip_all = 'Y';
-SELECT NULL skip_all FROM gv$instance WHERE instance_number = 8;
 DEF title = 'Execution Plan Cost per PHV from AWR for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
-@@&&skip_all.&&skip_diagnostics.sqld360_9a_pre_one.sql
+@@&&skip_inst8.&&skip_diagnostics.sqld360_9a_pre_one.sql
 
 COL phv1_ PRI
 COL phv2_ PRI


### PR DESCRIPTION
The sqldb360 collects info from the AWR for the cluster and for each instance.

The decision as to what info to collect from AWR for cluster and for each instance
was based on what instances were up at the time of collection.
This decision allowed for scenarios where data was not collected when the system
changed configurations during the window of collection such as :
1) RAC to single instance . This collected only the single instance up and not the other instances and not cluster.
2) RAC N-set nodes up to RAC M-set nodes up (N!=M). This collected only for the M nodes up and not for All M and N sets..

A new set of skip and present variables (skip_inst1,skip_inst2...) were defined in 0b
 that looks in the AWR for what instances are recorded and derives is_single_instance from them.
This replace most of the skip_all and SELECTs over gv$instance prior to every query.
Also consolidates all the 998## chart setup reports into one.

This transaction also fixes to additional reported issues :
- gather_stats_wr_sys.sql linesize
- SQL Plan Directive Objects spool file missing from eDB360, file 3b (another unprintable char issue)