### PR TITLE
Continuation of Missing Instance Information Fix

### DIFF
--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -504,11 +504,11 @@ SELECT TO_CHAR(CASE ROUND(AVG(TO_NUMBER(cpus.value))/AVG(TO_NUMBER(cores.value))
 
 -- get number of Hosts
 COL hosts_count NEW_V hosts_count FOR A2;
-SELECT TO_CHAR(COUNT(DISTINCT inst_id)) hosts_count FROM &&gv_object_prefix.osstat WHERE stat_name = 'NUM_CPU_CORES';
+SELECT TO_CHAR(ROUND(AVG(TO_NUMBER(value)))) hosts_count FROM (select count(distinct INSTANCE_NUMBER) value,snap_id FROM &&awr_object_prefix.osstat WHERE stat_name = 'NUM_CPU_CORES' group by snap_id);
 
 -- get cores_threads_hosts
 COL cores_threads_hosts NEW_V cores_threads_hosts;
-SELECT CASE TO_NUMBER('&&hosts_count.') WHEN 1 THEN 'cores:&&avg_core_count. threads:&&avg_thread_count.' ELSE 'cores:&&avg_core_count.(avg) threads:&&avg_thread_count.(avg) hosts:&&hosts_count.' END cores_threads_hosts FROM DUAL;
+SELECT CASE TO_NUMBER('&&hosts_count.') WHEN 1 THEN 'cores:&&avg_core_count. threads:&&avg_thread_count.' ELSE 'cores:&&avg_core_count.(avg) threads:&&avg_thread_count.(avg) hosts:&&hosts_count.(avg)' END cores_threads_hosts FROM DUAL;
 
 -- get block_size
 COL database_block_size NEW_V database_block_size;
@@ -598,11 +598,17 @@ BEGIN
   FOR i IN 9 .. 15 LOOP
    DBMS_OUTPUT.PUT_LINE('COL inst_'||LPAD(i, 2, '0')||' NOPRI;');
    DBMS_OUTPUT.PUT_LINE('DEF tit_'||LPAD(i, 2, '0')||' = '''';'); 
-  END LOOP
+  END LOOP;
 END;
 /
 SPO OFF;
 SET SERVEROUT OFF;
+
+hos echo "this is 0b" >> &&edb360_log3..txt
+hos pwd >> &&edb360_log3..txt
+hos cat &&chart_setup_driver. >> &&edb360_log3..txt
+
+HOS zip -j &&edb360_zip_filename. &&chart_setup_driver. >> &&edb360_log3..txt
 
 -- eAdam
 DEF edb360_eadam_snaps = '-666';

--- a/sql/edb360_0c_post.sql
+++ b/sql/edb360_0c_post.sql
@@ -18,8 +18,8 @@ ALTER SESSION SET SQL_TRACE = FALSE;
 
 PRO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--- Collect chart setup driver
-HOS zip -mj &&edb360_zip_filename. &&chart_setup_driver. >> &&edb360_log3..txt
+-- Remove chart setup driver
+HOS rm &&chart_setup_driver. >> &&edb360_log3..txt
 
 -- cleanup
 SET HEA ON; 

--- a/sql/edb360_1a_configuration.sql
+++ b/sql/edb360_1a_configuration.sql
@@ -29,7 +29,9 @@ DEF abstract = '&&abstract_uom.';
 BEGIN
   :sql_text := q'[
 WITH /* &&section_id..&&report_sequence. */ 
-rac AS (SELECT /*+ &&sq_fact_hints. */ COUNT(*) instances, CASE COUNT(*) WHEN 1 THEN 'Single-instance' ELSE COUNT(*)||'-node RAC cluster' END db_type FROM &&gv_object_prefix.instance),
+ rac AS (SELECT /*+ &&sq_fact_hints. */ COUNT(*) instances, CASE COUNT(*) WHEN 1 THEN 'Single-instance' ELSE COUNT(*)||'-node RAC cluster' END db_type FROM &&gv_object_prefix.instance),
+hrac AS (SELECT /*+ &&sq_fact_hints. */ CASE &&hosts_count. WHEN 1 THEN ' (historicly Single-instance in AWR)' ELSE ' (historicly &&hosts_count.-node RAC cluster in AWR)' END db_type 
+           FROM rac WHERE TO_CHAR(RAC.instances)<>&&hosts_count.),
 mem AS (SELECT /*+ &&sq_fact_hints. */ SUM(value) target FROM &&gv_object_prefix.system_parameter2 WHERE name = 'memory_target'),
 sga AS (SELECT /*+ &&sq_fact_hints. */ SUM(value) target FROM &&gv_object_prefix.system_parameter2 WHERE name = 'sga_target'),
 pga AS (SELECT /*+ &&sq_fact_hints. */ SUM(value) target FROM &&gv_object_prefix.system_parameter2 WHERE name = 'pga_aggregate_target'),
@@ -59,7 +61,7 @@ SELECT 'Database size:', TRIM(TO_CHAR(ROUND((data.bytes + temp.bytes + log.bytes
  UNION ALL
 SELECT 'Datafiles:', data.files||' (on '||data.tablespaces||' tablespaces)' FROM data
  UNION ALL
-SELECT 'Database configuration:', rac.db_type FROM rac
+SELECT 'Instance configuration:', rac.db_type||(select hrac.db_type FROM hrac ) FROM rac
  UNION ALL
 SELECT 'Database memory:', 
 CASE WHEN mem.target > 0 THEN 'MEMORY '||TRIM(TO_CHAR(ROUND(mem.target / POWER(2,30), 1), '999,990.0'))||' GB, ' END||
@@ -89,7 +91,7 @@ SELECT 'Physical RAM:', TRIM(TO_CHAR(ROUND(pmem.bytes / POWER(2,30), 1), '999,99
  UNION ALL
 SELECT 'Operating system:', db.platform_name FROM db
 ]';
-END;				
+END;
 /
 @@edb360_9a_pre_one.sql
 

--- a/sql/edb360_1e_resources.sql
+++ b/sql/edb360_1e_resources.sql
@@ -424,19 +424,21 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '4');
 @@&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-EF title = 'CPU Demand Series (Peak) for Instance 5';
+DEF title = 'CPU Demand Series (Peak) for Instance 5';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '5');
 @@&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
+DEF title = 'CPU Demand Series (Peak) for Instance 6';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '6');
 @@&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
+DEF title = 'CPU Demand Series (Peak) for Instance 7';
 DEF abstract = 'Number of Sessions demanding CPU. Based on peak demand per hour.<br />'
 DEF foot = 'Sessions "ON CPU" or "ON CPU" + "resmgr:cpu quantum"'
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');

--- a/sql/edb360_3e_os_stats.sql
+++ b/sql/edb360_3e_os_stats.sql
@@ -853,7 +853,6 @@ DEF abstract = '&&abstract_uom.';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 @@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
-
 @&&chart_setup_driver;
 
 DEF main_table = '&&awr_hist_prefix.OSSTAT';

--- a/sql/sqld360_0b_pre.sql
+++ b/sql/sqld360_0b_pre.sql
@@ -181,11 +181,11 @@ SELECT TO_CHAR(ROUND(AVG(TO_NUMBER(value)),1)) avg_thread_count FROM gv$osstat W
 
 -- get number of Hosts
 COL hosts_count NEW_V hosts_count FOR A2;
-SELECT TO_CHAR(COUNT(DISTINCT inst_id)) hosts_count FROM gv$osstat WHERE stat_name = 'NUM_CPU_CORES';
+SELECT TO_CHAR(ROUND(AVG(TO_NUMBER(value)))) hosts_count FROM (select count(distinct INSTANCE_NUMBER) value,snap_id FROM dba_hist_osstat WHERE stat_name = 'NUM_CPU_CORES' group by snap_id);
 
 -- get cores_threads_hosts
 COL cores_threads_hosts NEW_V cores_threads_hosts;
-SELECT CASE TO_NUMBER('&&hosts_count.') WHEN 1 THEN 'cores:&&avg_core_count. threads:&&avg_thread_count.' ELSE 'cores:&&avg_core_count.(avg) threads:&&avg_thread_count.(avg) hosts:&&hosts_count.' END cores_threads_hosts FROM DUAL;
+SELECT CASE TO_NUMBER('&&hosts_count.') WHEN 1 THEN 'cores:&&avg_core_count. threads:&&avg_thread_count.' ELSE 'cores:&&avg_core_count.(avg) threads:&&avg_thread_count.(avg) hosts:&&hosts_count.(avg)' END cores_threads_hosts FROM DUAL;
 
 --SET TERM OFF;
 
@@ -301,9 +301,9 @@ COL is_single_instance NEW_V is_single_instance FOR A1;
 
 WITH hist AS (
 SELECT DISTINCT instance_number
-  FROM &&awr_object_prefix.snapshot
+  FROM dba_hist_snapshot
 WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
-   AND dbid = &&edb360_dbid.
+   AND dbid = &&sqld360_dbid.
 )
 SELECT MAX(CASE instance_number WHEN 1 THEN '1' ELSE NULL END) inst1_present,
        MAX(CASE instance_number WHEN 2 THEN '2' ELSE NULL END) inst2_present,


### PR DESCRIPTION

- Fixed Typos
- Added check for V$ vs AWR difference in "System Under Observation"
  SUO does checks only in v$ views so it reports in the Current system configuration
and not the historical configuration.
  In order just advise that the current and historical configuration are different then
  a check on "Instance Configuration" add a () note in case of such difference.