### PR TITLE
19c bugfix for section 7b

### DIFF
--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -477,6 +477,12 @@ COL skip_18c_column NEW_V skip_18c_column;
 DEF skip_18c_script = '';
 COL skip_18c_script NEW_V skip_18c_script;
 SELECT ' -- skip 18c ' skip_18c_column, ' echo skip 18c ' skip_18c_script FROM &&v_object_prefix.instance WHERE version LIKE '18%';
+--
+DEF skip_19c_column = '';
+COL skip_19c_column NEW_V skip_19c_column;
+DEF skip_19c_script = '';
+COL skip_19c_script NEW_V skip_19c_script;
+SELECT ' -- skip 19c ' skip_19c_column, ' echo skip 19c ' skip_19c_script FROM &&v_object_prefix.instance WHERE version LIKE '19%';
 
 -- get average number of CPUs
 COL avg_cpu_count NEW_V avg_cpu_count FOR A6;

--- a/sql/edb360_7b_sql_sample.sql
+++ b/sql/edb360_7b_sql_sample.sql
@@ -49,7 +49,7 @@ DECLARE
   l_count NUMBER := 0;
   CURSOR sql_cur IS
               WITH ranked_sql AS (
-            SELECT /*+ &&sq_fact_sql_sample_hints. &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3. */ 
+            SELECT /*+ &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3. *//*&&sq_fact_sql_sample_hints.*/
                    /* &&section_id..&&report_sequence. */
                    &&skip_11g_column.&&skip_10g_column.con_id,
                    dbid,
@@ -95,7 +95,7 @@ DECLARE
                AND h.sql_id(+) = r.sql_id
             ),
             not_shared AS (
-            SELECT /*+ &&sq_fact_sql_sample_hints. &&section_id..&&report_sequence. */
+            SELECT /*+ &&section_id..&&report_sequence. *//*&&sq_fact_sql_sample_hints.*/
                    &&skip_11g_column.&&skip_10g_column.con_id,
                    sql_id, COUNT(*) child_cursors,
                    RANK() OVER (ORDER BY COUNT(*) DESC NULLS LAST) AS sql_rank

--- a/sql/edb360_7b_sql_sample.sql
+++ b/sql/edb360_7b_sql_sample.sql
@@ -170,7 +170,7 @@ DECLARE
             )
             SELECT rank_num,
                    &&skip_11g_column.&&skip_10g_column.con_id,
-                   &&skip_12c_column.&&skip_18c_column.TO_NUMBER(NULL) con_id,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ts.con_id) pdb_name,
                    &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
                    sql_id,
@@ -189,7 +189,7 @@ DECLARE
              UNION ALL
             SELECT sql_rank rank_num,
                    &&skip_11g_column.&&skip_10g_column.con_id,
-                   &&skip_12c_column.&&skip_18c_column.TO_NUMBER(NULL) con_id,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ns.con_id) pdb_name,
                    &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
                    sql_id,
@@ -209,7 +209,7 @@ DECLARE
              UNION ALL
             SELECT rn rank_num,
                    &&skip_11g_column.&&skip_10g_column.con_id,
-                   &&skip_12c_column.&&skip_18c_column.TO_NUMBER(NULL) con_id,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ts.con_id) pdb_name,
                    &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
                    sample_sql_id sql_id,

--- a/sql/edb360_7b_sql_sample.sql
+++ b/sql/edb360_7b_sql_sample.sql
@@ -172,7 +172,7 @@ DECLARE
                    &&skip_11g_column.&&skip_10g_column.con_id,
                    &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ts.con_id) pdb_name,
-                   &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.NULL pdb_name,
                    sql_id,
                    db_time_hrs, -- not null means Top as per DB time
                    cpu_time_hrs, -- not null means Top as per DB time
@@ -191,7 +191,7 @@ DECLARE
                    &&skip_11g_column.&&skip_10g_column.con_id,
                    &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ns.con_id) pdb_name,
-                   &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.NULL pdb_name,
                    sql_id,
                    NULL db_time_hrs, -- not null means Top as per DB time
                    NULL cpu_time_hrs, -- not null means Top as per DB time
@@ -211,7 +211,7 @@ DECLARE
                    &&skip_11g_column.&&skip_10g_column.con_id,
                    &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.TO_NUMBER(NULL) con_id,
                    &&skip_11g_column.&&skip_10g_column.(SELECT pd.pdb_name FROM dba_pdbs pd WHERE pd.con_id = ts.con_id) pdb_name,
-                   &&skip_12c_column.&&skip_18c_column.NULL pdb_name,
+                   &&skip_12c_column.&&skip_18c_column.&&skip_19c_column.NULL pdb_name,
                    sample_sql_id sql_id,
                    NULL db_time_hrs, -- not null means Top as per DB time
                    NULL cpu_time_hrs, -- not null means Top as per DB time

--- a/sql/sqld360_0b_pre.sql
+++ b/sql/sqld360_0b_pre.sql
@@ -235,6 +235,9 @@ SELECT '--' skip_12r1 FROM v$instance WHERE version LIKE '12.1.%';
 DEF skip_18c = '';
 COL skip_18c NEW_V skip_18c;
 SELECT '--' skip_18c FROM v$instance WHERE version LIKE '18.%';
+DEF skip_19c = '';
+COL skip_19c NEW_V skip_19c;
+SELECT '--' skip_19c FROM v$instance WHERE version LIKE '19.%';
 --
 
 

--- a/sql/sqld360_3a_objects.sql
+++ b/sql/sqld360_3a_objects.sql
@@ -297,8 +297,8 @@ SELECT /*+ &&top_level_hints. */
  WHERE (owner, table_name) IN (SELECT /*+ UNNEST */ object_owner, object_name FROM plan_table WHERE statement_id = 'LIST_OF_TABLES' AND remarks = '&&sqld360_sqlid.')
    AND num_buckets <= 253
    AND histogram <> 'NONE'
-   &&skip_12c.&&skip_18c.AND char_length > 32
-   &&skip_12c.&&skip_18c.AND data_length > 32
+   &&skip_12c.&&skip_18c.&&skip_19c.AND char_length > 32
+   &&skip_12c.&&skip_18c.&&skip_19c.AND data_length > 32
    &&skip_10g.&&skip_11g.AND char_length > 64
    &&skip_10g.&&skip_11g.AND data_length > 64
    AND avg_col_len > 6

--- a/sql/sqld360_3d_histograms.sql
+++ b/sql/sqld360_3d_histograms.sql
@@ -64,7 +64,7 @@ BEGIN
     -- need to check if dba_stat_extensions existed in 10g, likely not so need to introduce conditional code here
     FOR j IN (SELECT col.owner, col.table_name, column_name, 
                      &&skip_10g.NVL2(exts.extension, exts.extension, col.column_name) display_name, 
-                     &&skip_11g.&&skip_12c.&&skip_18c.col.column_name display_name,
+                     &&skip_11g.&&skip_12c.&&skip_18c.&&skip_19c.col.column_name display_name,
                      col.data_type, col.histogram, col.sample_size, col.num_nulls, col.num_buckets
                 FROM dba_tab_cols col
                      &&skip_10g.,dba_stat_extensions exts


### PR DESCRIPTION
Added Skip 19c variables where skip 18c already exists
Removed two MATERIALIZE NO_MERGE hints from cursor in PL/SQL in edb360_7b_sql_sample.sql to evade ORA-32036 on 19.3.