### PR TITLE
AWR Points Feature V1

### DIFF
--- a/sql/aegcfg.sql
+++ b/sql/aegcfg.sql
@@ -1,3 +1,3 @@
 DEF edb360_conf_incl_awr_diff_rpt = 'N';
 DEF edb360_conf_incl_plot_awr ='Y';
-DEF edb360_sections='1a,5a,5b,7a';
+DEF edb360_sections='';

--- a/sql/aegcfg.sql
+++ b/sql/aegcfg.sql
@@ -1,0 +1,3 @@
+DEF edb360_conf_incl_awr_diff_rpt = 'N';
+DEF edb360_conf_incl_plot_awr ='Y';
+DEF edb360_sections='1a,5a,5b,7a';

--- a/sql/edb360_00_config.sql
+++ b/sql/edb360_00_config.sql
@@ -110,12 +110,15 @@ DEF edb360_conf_incl_bar  = 'Y';
 -- excluding awr reports substantially reduces usability with minimal performance gain
 DEF edb360_conf_incl_perfhub = 'Y';
 DEF edb360_conf_incl_awr_rpt = 'Y';
-DEF edb360_conf_incl_awr_diff_rpt = 'Y';
+DEF edb360_conf_incl_awr_diff_rpt = 'Y'; 
 DEF edb360_conf_incl_awr_range_rpt = 'N';
 DEF edb360_conf_incl_addm_rpt = 'N';
 DEF edb360_conf_incl_ash_rpt = 'N';
 DEF edb360_conf_incl_ash_analy_rpt = 'N';
 DEF edb360_conf_incl_tkprof = 'Y';
+
+-- Plotting the points where AWR reports are taken by the edb360 
+DEF edb360_conf_incl_plot_awr ='N'; 
 
 -- up to how many max peaks to consider for reports for entire history work days (between 0 and 3)
 DEF edb360_max_work_days_peaks = 3;

--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -877,6 +877,16 @@ DEF series_13 = ''
 DEF series_14 = ''
 DEF series_15 = ''
 
+-- Variables and controls for 9e_one_line_chart_plus
+DEF skip_lchp = '--skip--';
+VAR AWRPointsIni VARCHAR2(100);
+VAR addAWRPoints VARCHAR2(32);
+BEGIN
+ :addAWRPoints:=(CASE '&&is_single_instance.' WHEN 'Y' THEN '' ELSE 'C' END)||
+  '&&inst1_present.&&inst2_present.&&inst3_present.&&inst4_present.&&inst5_present.&&inst6_present.&&inst7_present.&&inst8_present.';
+END;
+/
+
 -- get udump directory path
 COL edb360_udump_path NEW_V edb360_udump_path FOR A500;
 SELECT value||DECODE(INSTR(value, '/'), 0, '\', '/') edb360_udump_path FROM &&v_dollar.parameter2 WHERE name = 'user_dump_dest';

--- a/sql/edb360_5a_ash.sql
+++ b/sql/edb360_5a_ash.sql
@@ -137,7 +137,6 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 @@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
-DEF title = 'AAS per Wait Class for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 @@&&skip_inst8.edb360_9a_pre_one.sql
 
@@ -253,6 +252,7 @@ DEF title = 'AAS waiting on Administrative per Instance';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = ''Administrative''');
 @@&&skip_all.edb360_9a_pre_one.sql
 
+DEF skip_lch = '--skip--';
 SPO &&edb360_main_report..html APP;
 PRO </ol>
 SPO OFF;

--- a/sql/edb360_5a_ash.sql
+++ b/sql/edb360_5a_ash.sql
@@ -137,6 +137,7 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '7');
 @@&&skip_inst7.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
+DEF title = 'AAS per Wait Class for Instance 8';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 @@&&skip_inst8.edb360_9a_pre_one.sql
 

--- a/sql/edb360_7a_cluster_query.sql
+++ b/sql/edb360_7a_cluster_query.sql
@@ -1,0 +1,327 @@
+              WITH
+              expensive2 AS (
+              SELECT /*+ &&sq_fact_hints. &&ds_hint. &&section_id. */
+                     h.dbid, 
+                     LAG(h.snap_id) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) bid,
+                     h.snap_id eid,
+                     CAST(s.begin_interval_time AS DATE) begin_date,
+                     CAST(s.end_interval_time AS DATE) end_date,
+                     h.value - LAG(h.value) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) value,
+                     s.startup_time - LAG(s.startup_time) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) startup_time_interval
+                FROM &&awr_object_prefix.sys_time_model h,
+                     &&awr_object_prefix.snapshot s
+               WHERE h.stat_name IN ('DB time', 'background elapsed time')
+                 AND h.snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+                 AND h.dbid = &&edb360_dbid.
+                 AND s.snap_id = h.snap_id
+                 AND s.dbid = h.dbid
+                 AND s.instance_number = h.instance_number
+                 AND s.end_interval_time - s.begin_interval_time > TO_DSINTERVAL('+00 00:01:00.000000') -- exclude snaps less than 1m appart
+                 --AND s.end_interval_time BETWEEN TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') - TO_DSINTERVAL('+&&history_days. 00:00:00.000000') AND TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') -- includes all options
+                 --AND s.end_interval_time BETWEEN TO_TIMESTAMP('&&edb360_date_from.', '&&edb360_date_format.') AND TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') -- includes all options
+              ),
+              expensive AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ dbid, bid, eid, begin_date, end_date, SUM(value) value
+                FROM expensive2
+               WHERE startup_time_interval = TO_DSINTERVAL('+00 00:00:00.000000') -- include only snaps from same startup
+                 AND value > 0
+               GROUP BY
+                     dbid, bid, eid, begin_date, end_date
+              ),
+              max_&&hist_work_days.wd1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 1
+              ),
+              max_&&hist_work_days.wd2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1)
+              ),
+              max_&&hist_work_days.wd3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd2)
+              ),
+              min_&&hist_work_days.wd AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_min_work_days_peaks. >= 1
+              ),
+              max_&&history_days.d1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 1
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3)
+              ),
+              max_&&history_days.d2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION 
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d1)
+              ),
+              max_&&history_days.d3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION 
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d1
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d2)
+              ),
+              med_&&history_days.d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_med_history. >= 1
+              ),
+              max_5wd1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 1
+              ),
+              max_5wd2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_5wd1)
+              ),
+              max_5wd3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2)
+              ),
+              min_5wd AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_min_5wd_peaks. >= 1
+              ),
+              max_7d1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 1
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3)
+              ),
+              max_7d2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3
+                                   UNION
+                                   SELECT value FROM max_7d1)
+              ),
+              max_7d3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3
+                                   UNION
+                                   SELECT value FROM max_7d1
+                                   UNION
+                                   SELECT value FROM max_7d2)
+              ),
+              med_7d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_med_7d. >= 1
+              ),
+              small_range AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd1' rep, 50 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd2' rep, 53 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd3' rep, 56 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'min&&hist_work_days.wd' rep, 100 ob
+                FROM expensive e,
+                     min_&&hist_work_days.wd m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d1' rep, 60 ob
+                FROM expensive e,
+                     max_&&history_days.d1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d2' rep, 63 ob
+                FROM expensive e,
+                     max_&&history_days.d2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d3' rep, 66 ob
+                FROM expensive e,
+                     max_&&history_days.d3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med&&history_days.d' rep, 80 ob
+                FROM expensive e,
+                     med_&&history_days.d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med&&history_days.d' rep, 15 ob
+                FROM expensive e,
+                     med_&&history_days.d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd1' rep, 30 ob
+                FROM expensive e,
+                     max_5wd1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd2' rep, 33 ob
+                FROM expensive e,
+                     max_5wd2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd3' rep, 36 ob
+                FROM expensive e,
+                     max_5wd3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'min5wd' rep, 90 ob
+                FROM expensive e,
+                     min_5wd m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d1' rep, 40 ob
+                FROM expensive e,
+                     max_7d1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d2' rep, 43 ob
+                FROM expensive e,
+                     max_7d2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d3' rep, 46 ob
+                FROM expensive e,
+                     max_7d3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med7d' rep, 70 ob
+                FROM expensive e,
+                     med_7d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med7d' rep, 10 ob
+                FROM expensive e,
+                     med_7d m
+               WHERE m.value = e.value
+              ),
+              max_&&history_days.d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(dbid) dbid, MIN(bid) bid, MAX(eid) eid, MIN(begin_date) begin_date, MAX(end_date) end_date, 'max&&history_days.d' rep, 69 ob
+                FROM small_range
+               WHERE rep IN ('max&&hist_work_days.wd1', 'max&&hist_work_days.wd2', 'max&&hist_work_days.wd3', 
+                             'max&&history_days.d1', 'max&&history_days.d2', 'max&&history_days.d3', 
+                             'max5wd1', 'max5wd2', 'max5wd3', 
+                             'max7d1', 'max7d2', 'max7d3')
+                 AND &&history_days. > 10
+              HAVING COUNT(*) > 0
+              ),
+              max_7d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(dbid) dbid, MIN(bid) bid, MAX(eid) eid, MIN(begin_date) begin_date, MAX(end_date) end_date, 'max7d' rep, 49 ob
+                FROM small_range
+               WHERE rep IN ('max5wd1', 'max5wd2', 'max5wd3', 
+                             'max7d1', 'max7d2', 'max7d3')
+                 --AND &&history_days. > 10
+              HAVING COUNT(*) > 0
+              )
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM small_range
+               UNION ALL
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM max_&&history_days.d
+               WHERE '&&edb360_conf_incl_awr_range_rpt.' = 'Y'
+               UNION ALL
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM max_7d
+               WHERE '&&edb360_conf_incl_awr_range_rpt.' = 'Y'

--- a/sql/edb360_7a_inst_query.sql
+++ b/sql/edb360_7a_inst_query.sql
@@ -1,0 +1,328 @@
+              WITH
+              expensive2 AS (
+              SELECT /*+ &&sq_fact_hints. &&ds_hint. &&section_id. */
+                     h.dbid, 
+                     LAG(h.snap_id) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) bid,
+                     h.snap_id eid,
+                     CAST(s.begin_interval_time AS DATE) begin_date,
+                     CAST(s.end_interval_time AS DATE) end_date,
+                     h.value - LAG(h.value) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) value,
+                     s.startup_time - LAG(s.startup_time) OVER (PARTITION BY h.dbid, h.instance_number, h.stat_id ORDER BY h.snap_id) startup_time_interval
+                FROM &&awr_object_prefix.sys_time_model h,
+                     &&awr_object_prefix.snapshot s
+               WHERE h.instance_number = i.instance_number
+                 AND h.stat_name IN ('DB time', 'background elapsed time')
+                 AND h.snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+                 AND h.dbid = &&edb360_dbid.
+                 AND s.snap_id = h.snap_id
+                 AND s.dbid = h.dbid
+                 AND s.instance_number = h.instance_number
+                 AND s.end_interval_time - s.begin_interval_time > TO_DSINTERVAL('+00 00:01:00.000000') -- exclude snaps less than 1m appart
+                 --AND s.end_interval_time BETWEEN TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') - TO_DSINTERVAL('+&&history_days. 00:00:00.000000') AND TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') -- includes all options
+                 --AND s.end_interval_time BETWEEN TO_TIMESTAMP('&&edb360_date_from.', '&&edb360_date_format.') AND TO_TIMESTAMP('&&edb360_date_to.', '&&edb360_date_format.') -- includes all options
+              ),
+              expensive AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ dbid, bid, eid, begin_date, end_date, SUM(value) value
+                FROM expensive2
+               WHERE startup_time_interval = TO_DSINTERVAL('+00 00:00:00.000000') -- include only snaps from same startup
+                 AND value > 0
+               GROUP BY
+                     dbid, bid, eid, begin_date, end_date
+              ),
+              max_&&hist_work_days.wd1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 1
+              ),
+              max_&&hist_work_days.wd2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1)
+              ),
+              max_&&hist_work_days.wd3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_max_work_days_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd2)
+              ),
+              min_&&hist_work_days.wd AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 AND &&history_days. > 10
+                 AND &&edb360_min_work_days_peaks. >= 1
+              ),
+              max_&&history_days.d1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 1
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3)
+              ),
+              max_&&history_days.d2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION 
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d1)
+              ),
+              max_&&history_days.d3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_max_history_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_&&hist_work_days.wd1
+                                   UNION 
+                                   SELECT value FROM max_&&hist_work_days.wd2
+                                   UNION
+                                   SELECT value FROM max_&&hist_work_days.wd3
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d1
+                                   UNION
+                                   SELECT value FROM max_&&history_days.d2)
+              ),
+              med_&&history_days.d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - &&history_days. AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 -- avoids selecting same twice
+                 AND &&history_days. > 10
+                 AND &&edb360_med_history. >= 1
+              ),
+              max_5wd1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 1
+              ),
+              max_5wd2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_5wd1)
+              ),
+              max_5wd3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_5wd_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2)
+              ),
+              min_5wd AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 AND TO_CHAR(end_date, 'D') BETWEEN '2' AND '6' /* between Monday and Friday */
+                 AND TO_CHAR(end_date, 'HH24MM') BETWEEN '&&edb360_conf_work_time_from.' AND '&&edb360_conf_work_time_to.' 
+                 --AND &&history_days. > 10
+                 AND &&edb360_min_5wd_peaks. >= 1
+              ),
+              max_7d1 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 1
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3)
+              ),
+              max_7d2 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 2
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3
+                                   UNION
+                                   SELECT value FROM max_7d1)
+              ),
+              max_7d3 AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MAX(value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_max_7d_peaks. >= 3
+                 AND value NOT IN (SELECT value FROM max_5wd1
+                                   UNION
+                                   SELECT value FROM max_5wd2
+                                   UNION
+                                   SELECT value FROM max_5wd3
+                                   UNION
+                                   SELECT value FROM max_7d1
+                                   UNION
+                                   SELECT value FROM max_7d2)
+              ),
+              med_7d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY value) value
+                FROM expensive
+               WHERE end_date BETWEEN TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') - 8 AND TO_DATE('&&edb360_date_to.', '&&edb360_date_format.') /* -1 */ -- avoids selecting same twice
+                 --AND &&history_days. > 10
+                 AND &&edb360_med_7d. >= 1
+              ),
+              small_range AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd1' rep, 50 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd2' rep, 53 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&hist_work_days.wd3' rep, 56 ob
+                FROM expensive e,
+                     max_&&hist_work_days.wd3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'min&&hist_work_days.wd' rep, 100 ob
+                FROM expensive e,
+                     min_&&hist_work_days.wd m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d1' rep, 60 ob
+                FROM expensive e,
+                     max_&&history_days.d1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d2' rep, 63 ob
+                FROM expensive e,
+                     max_&&history_days.d2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max&&history_days.d3' rep, 66 ob
+                FROM expensive e,
+                     max_&&history_days.d3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med&&history_days.d' rep, 80 ob
+                FROM expensive e,
+                     med_&&history_days.d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med&&history_days.d' rep, 15 ob
+                FROM expensive e,
+                     med_&&history_days.d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd1' rep, 30 ob
+                FROM expensive e,
+                     max_5wd1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd2' rep, 33 ob
+                FROM expensive e,
+                     max_5wd2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max5wd3' rep, 36 ob
+                FROM expensive e,
+                     max_5wd3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'min5wd' rep, 90 ob
+                FROM expensive e,
+                     min_5wd m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d1' rep, 40 ob
+                FROM expensive e,
+                     max_7d1 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d2' rep, 43 ob
+                FROM expensive e,
+                     max_7d2 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'max7d3' rep, 46 ob
+                FROM expensive e,
+                     max_7d3 m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med7d' rep, 70 ob
+                FROM expensive e,
+                     med_7d m
+               WHERE m.value = e.value
+               UNION
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ e.dbid, e.bid, e.eid, e.begin_date, e.end_date, 'med7d' rep, 10 ob
+                FROM expensive e,
+                     med_7d m
+               WHERE m.value = e.value
+              ),
+              max_&&history_days.d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(dbid) dbid, MIN(bid) bid, MAX(eid) eid, MIN(begin_date) begin_date, MAX(end_date) end_date, 'max&&history_days.d' rep, 69 ob
+                FROM small_range
+               WHERE rep IN ('max&&hist_work_days.wd1', 'max&&hist_work_days.wd2', 'max&&hist_work_days.wd3', 
+                             'max&&history_days.d1', 'max&&history_days.d2', 'max&&history_days.d3', 
+                             'max5wd1', 'max5wd2', 'max5wd3', 
+                             'max7d1', 'max7d2', 'max7d3')
+                 AND &&history_days. > 10
+              HAVING COUNT(*) > 0
+              ),
+              max_7d AS (
+              SELECT /*+ &&sq_fact_hints. &&section_id. */ MIN(dbid) dbid, MIN(bid) bid, MAX(eid) eid, MIN(begin_date) begin_date, MAX(end_date) end_date, 'max7d' rep, 49 ob
+                FROM small_range
+               WHERE rep IN ('max5wd1', 'max5wd2', 'max5wd3', 
+                             'max7d1', 'max7d2', 'max7d3')
+                 --AND &&history_days. > 10
+              HAVING COUNT(*) > 0
+              )
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM small_range
+               UNION ALL
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM max_&&history_days.d
+               WHERE '&&edb360_conf_incl_awr_range_rpt.' = 'Y'
+               UNION ALL
+              SELECT dbid, bid, eid, begin_date, end_date, rep, ob
+                FROM max_7d
+               WHERE '&&edb360_conf_incl_awr_range_rpt.' = 'Y'

--- a/sql/edb360_9a_pre_one.sql
+++ b/sql/edb360_9a_pre_one.sql
@@ -69,12 +69,20 @@ COL edb360_prev_child_number NEW_V edb360_prev_child_number NOPRI;
 SELECT prev_sql_id edb360_prev_sql_id, TO_CHAR(prev_child_number) edb360_prev_child_number FROM &&v_dollar.session WHERE sid = SYS_CONTEXT('USERENV', 'SID')
 /
 
+-- choose one_line_plus over one_line if any of one_line_plus features are enabled.
+COL skip_lch   NEW_V skip_lch  NOPRI;
+COL skip_lchp  NEW_V skip_lchp NOPRI;
+SELECT CASE WHEN '&&skip_lch.' IS NULL AND '&&edb360_conf_incl_plot_awr.' ='Y' THEN ' echo skip html ' ELSE '&&skip_lch.' END skip_lch
+     , CASE WHEN '&&skip_lch.' IS NULL AND '&&edb360_conf_incl_plot_awr.' ='Y' THEN ' ' ELSE ' echo skip html ' END skip_lchp
+  FROM DUAL;
+
 -- execute one sql
 @@&&edb360_bypass.&&skip_html.&&edb360_skip_html.edb360_9b_one_html.sql
 @@&&edb360_bypass.&&skip_html.&&edb360_skip_xml.edb360_9g_one_xml.sql
 @@&&edb360_bypass.&&skip_text.&&edb360_skip_text.edb360_9c_one_text.sql
 @@&&edb360_bypass.&&skip_csv.&&edb360_skip_csv.edb360_9d_one_csv.sql
 @@&&edb360_bypass.&&skip_lch.&&edb360_skip_line.edb360_9e_one_line_chart.sql
+@@&&edb360_bypass.&&skip_lchp.&&edb360_skip_line.edb360_9e_one_line_chart_plus.sql
 @@&&edb360_bypass.&&skip_lch2.&&edb360_skip_line.edb360_9e_two_line_chart.sql
 @@&&edb360_bypass.&&skip_pch.&&edb360_skip_pie.edb360_9f_one_pie_chart.sql
 @@&&edb360_bypass.&&skip_bch.&&edb360_skip_bar.edb360_9h_one_bar_chart.sql
@@ -119,6 +127,7 @@ DEF skip_html = '';
 DEF skip_text = '';
 DEF skip_csv = '';
 DEF skip_lch = '--skip--';
+DEF skip_lchp = '--skip--';
 DEF skip_lch2 = '--skip--';
 DEF skip_pch = '--skip--';
 DEF skip_bch = '--skip--';

--- a/sql/edb360_9e_one_line_chart_plus.sql
+++ b/sql/edb360_9e_one_line_chart_plus.sql
@@ -1,0 +1,404 @@
+-- This chart creator does the same as 9e_one_line_chart.sql plus :
+-- * Plots the begin date of the generated AWR report in 7a.
+
+-- add seq to one_spool_filename
+EXEC :file_seq := :file_seq + 1;
+SELECT LPAD(:file_seq, 5, '0')||'_&&spool_filename.' one_spool_filename FROM DUAL;
+
+-- display
+SELECT TO_CHAR(SYSDATE, 'HH24:MI:SS') hh_mm_ss FROM DUAL;
+SET TERM ON;
+SPO &&edb360_log..txt APP;
+PRO &&hh_mm_ss. &&section_id. "&&one_spool_filename._line_chart.html"
+SPO OFF;
+SET TERM OFF;
+
+-- update main report
+SPO &&edb360_main_report..html APP;
+PRO <a href="&&one_spool_filename._line_chart.html">line</a>
+SPO OFF;
+
+-- get time t0
+EXEC :get_time_t0 := DBMS_UTILITY.get_time;
+
+-- header
+SPO &&edb360_output_directory.&&one_spool_filename._line_chart.html;
+@@edb360_0d_html_header.sql
+PRO <!-- &&one_spool_filename._line_chart.html $ -->
+
+-- chart header
+PRO    &&edb360_conf_google_charts.
+PRO    <script type="text/javascript" src="&&edb360_output_directory.edb360_awr_points.js"></script>
+PRO    <script type="text/javascript">
+PRO      google.load("visualization", "1", {packages:["corechart","controls"]});
+PRO      google.setOnLoadCallback(drawChart);
+PRO     var racIdx = 0;
+PRO     var instIdx1 = 0;
+PRO     var instIdx2 = 0;
+PRO     var instIdx3 = 0;
+PRO     var instIdx4 = 0;
+PRO     var instIdx5 = 0;
+PRO     var instIdx6 = 0;
+PRO     var instIdx7 = 0;
+PRO     var instIdx8 = 0;
+PRO     var data = [];
+PRO     var chartData = [
+-- body
+SET SERVEROUT ON;
+SET SERVEROUT ON SIZE 1000000;
+SET SERVEROUT ON SIZE UNL;
+VAR edb360_series_props CLOB;
+VAR AWRPointsControls CLOB;
+
+DECLARE
+  cur SYS_REFCURSOR;
+  l_snap_id NUMBER;
+  l_begin_time VARCHAR2(32);
+  l_end_time VARCHAR2(32);
+  l_col_01 NUMBER;
+  l_col_02 NUMBER;
+  l_col_03 NUMBER;
+  l_col_04 NUMBER;
+  l_col_05 NUMBER;
+  l_col_06 NUMBER;
+  l_col_07 NUMBER;
+  l_col_08 NUMBER;
+  l_col_09 NUMBER;
+  l_col_10 NUMBER;
+  l_col_11 NUMBER;
+  l_col_12 NUMBER;
+  l_col_13 NUMBER;
+  l_col_14 NUMBER;
+  l_col_15 NUMBER;
+  l_line VARCHAR2(1000);
+  l_sql_text VARCHAR2(32767);
+  l_ncol NUMBER:=0;
+  l_lastcol varchar2(2);
+ PROCEDURE addAWRP(id IN NUMBER,condition IN VARCHAR2) is
+ BEGIN
+  IF instr(:addAWRPoints,nvl(condition,'-'))>0 THEN 
+   :AWRPointsControls:=:AWRPointsControls||'<input type="checkbox" onchange="toggleAWRPoint('||id||');">'||
+    (CASE WHEN id=0 THEN 'Cluster' ELSE to_char(id) END)||'</input>';
+  END IF;
+ END;
+BEGIN
+  EXECUTE IMMEDIATE 'ALTER SESSION SET NLS_DATE_FORMAT = ''&&edb360_date_format.''';
+  l_line := '[''Date''';
+  IF '&&edb360_conf_incl_plot_awr.' ='Y' THEN
+   l_line := l_line || q'[, {'type': 'string', 'role': 'annotation' } ]';
+   l_line := l_line || q'[, {'type': 'string', 'role': 'tooltip' , 'p':{'html': true} } ]';
+  END IF; 
+  IF '&&tit_01.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_01.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='0';
+  END IF;
+  IF '&&tit_02.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_02.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='1';
+  END IF;
+  IF '&&tit_03.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_03.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='2';
+  END IF;
+  IF '&&tit_04.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_04.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='3';
+  END IF;
+  IF '&&tit_05.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_05.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='4';
+  END IF;
+  IF '&&tit_06.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_06.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='5';
+  END IF;
+  IF '&&tit_07.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_07.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='6';
+  END IF;
+  IF '&&tit_08.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_08.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='7';
+  END IF;
+  IF '&&tit_09.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_09.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='8';
+  END IF;
+  IF '&&tit_10.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_10.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='9';
+  END IF;
+  IF '&&tit_11.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_11.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='10';
+  END IF;
+  IF '&&tit_12.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_12.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='11';
+  END IF;
+  IF '&&tit_13.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_13.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='12';
+  END IF;
+  IF '&&tit_14.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_14.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='13';
+  END IF;
+  IF '&&tit_15.' IS NOT NULL THEN
+    l_line := l_line||', ''&&tit_15.'''; 
+    l_ncol := l_ncol +1;
+    l_lastcol:='14';
+  END IF;
+
+  l_line := l_line||']';
+  DBMS_OUTPUT.PUT_LINE(l_line);
+  --OPEN cur FOR :sql_text;
+  l_sql_text := DBMS_LOB.SUBSTR(:sql_text); -- needed for 10g
+  OPEN cur FOR l_sql_text; -- needed for 10g
+  LOOP
+    FETCH cur INTO l_snap_id, l_begin_time, l_end_time,
+    l_col_01, l_col_02, l_col_03, l_col_04, l_col_05,
+    l_col_06, l_col_07, l_col_08, l_col_09, l_col_10,
+    l_col_11, l_col_12, l_col_13, l_col_14, l_col_15;
+    EXIT WHEN cur%NOTFOUND;
+    IF l_col_01 IS NOT NULL AND l_col_02 IS NOT NULL AND l_col_03 IS NOT NULL AND l_col_04 IS NOT NULL AND l_col_05 IS NOT NULL AND l_col_06 IS NOT NULL AND l_col_07 IS NOT NULL AND l_col_08 IS NOT NULL AND l_col_09 IS NOT NULL AND l_col_10 IS NOT NULL AND l_col_11 IS NOT NULL AND l_col_12 IS NOT NULL AND l_col_13 IS NOT NULL AND l_col_14 IS NOT NULL AND l_col_15 IS NOT NULL THEN
+      l_line := ', [new Date('||SUBSTR(l_end_time,1,4)||','||
+      (TO_NUMBER(SUBSTR(l_end_time,6,2)) - 1)||','||
+      SUBSTR(l_end_time,9,2)||','||
+      SUBSTR(l_end_time,12,2)||','||
+      SUBSTR(l_end_time,15,2)||','||
+      NVL(SUBSTR(l_end_time,18,2),'0')||
+      ')';
+      IF '&&edb360_conf_incl_plot_awr.' = 'Y' THEN
+       l_line := l_line||', null, null ';      
+      END IF;       
+      IF '&&tit_01.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_01; 
+      END IF;
+      IF '&&tit_02.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_02; 
+      END IF;
+      IF '&&tit_03.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_03; 
+      END IF;
+      IF '&&tit_04.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_04; 
+      END IF;
+      IF '&&tit_05.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_05; 
+      END IF;
+      IF '&&tit_06.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_06; 
+      END IF;
+      IF '&&tit_07.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_07; 
+      END IF;
+      IF '&&tit_08.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_08; 
+      END IF;
+      IF '&&tit_09.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_09; 
+      END IF;
+      IF '&&tit_10.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_10; 
+      END IF;
+      IF '&&tit_11.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_11; 
+      END IF;
+      IF '&&tit_12.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_12; 
+      END IF;
+      IF '&&tit_13.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_13; 
+      END IF;
+      IF '&&tit_14.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_14; 
+      END IF;
+      IF '&&tit_15.' IS NOT NULL THEN
+        l_line := l_line||', '||l_col_15; 
+      END IF;             
+      l_line := l_line||']';
+      DBMS_OUTPUT.PUT_LINE(l_line);
+    END IF;
+  END LOOP;
+  CLOSE cur;
+
+ :AWRPointsControls:=' ';
+ :AWRPointsIni:=' ';
+ IF '&&edb360_conf_incl_plot_awr.' ='Y' THEN
+  :AWRPointsControls:='<div id="AWRPointsControls_div" style="border: 1px solid #ccc">AWR Points Instances: ';
+  addAWRP(1,'&&inst1_present.');
+  addAWRP(2,'&&inst2_present.');
+  addAWRP(3,'&&inst3_present.');
+  addAWRP(4,'&&inst4_present.');
+  addAWRP(5,'&&inst5_present.');
+  addAWRP(6,'&&inst6_present.');
+  addAWRP(7,'&&inst7_present.');
+  addAWRP(8,'&&inst8_present.');
+  addAWRP(0,NVL('&&is_single_instance.','C'));  
+  :AWRPointsControls:=:AWRPointsControls||'<input type="checkbox" onchange="toggleAnnotations();" checked>long annotations</input></div>';
+  :AWRPointsIni:='initializeArrays('||l_ncol||');';
+ ELSE
+  l_lastcol:='-';
+ END IF; 
+END;
+/
+SET SERVEROUT OFF;
+
+SET HEA OFF;
+
+PRO        ];
+-- line chart footer
+
+PRO      function drawChart() {     
+PRO        chartDataPoints = new google.visualization.arrayToDataTable(chartData);
+PRO        var programmaticChart = new google.visualization.ChartWrapper({
+PRO        chartType:'&&chartype.',
+PRO        containerId:'linechart',
+PRO        dataTable: chartDataPoints,
+PRO        options: {&&stacked.
+PRO          chartArea:{left:90, top:75, width:'65%', height:'70%'},
+PRO          backgroundColor: {fill: 'white', stroke: '#336699', strokeWidth: 1},
+PRO          explorer: {actions: ['dragToZoom', 'rightClickToReset'], maxZoomIn: 0.01},
+PRO          title: '&&section_id..&&report_sequence.. &&title.&&title_suffix.',
+PRO          titleTextStyle: {fontSize: 18, bold: false},
+PRO          focusTarget: 'category',
+PRO          legend: {position: 'right', textStyle: {fontSize: 14}},
+PRO          tooltip: {isHtml: true, textStyle: {fontSize: 14}},
+PRO          annotations: { style: 'line' , stem: { color:'#000000' } },
+PRO          hAxis: {title: '&&haxis.', gridlines: {count: -1}, titleTextStyle: {fontSize: 16, bold: false}},
+PRO          series: { 0: { &&series_01.},  1: { &&series_02.},  2: { &&series_03.},  3: { &&series_04.},  4: { &&series_05.},  
+PRO                    5: { &&series_06.},  6: { &&series_07.},  7: { &&series_08.},  8: { &&series_09.},  9: { &&series_10.},
+PRO                   10: { &&series_11.}, 11: { &&series_12.}, 12: { &&series_13.}, 13: { &&series_14.}, 14: { &&series_15.}
+PRO          },
+PRO          vAxis: {title: '&&vaxis.', &&vbaseline. gridlines: {count: -1}, titleTextStyle: {fontSize: 16, bold: false}}
+PRO        }
+PRO      });
+PRO      programmaticChart.draw();
+PRO /*
+PRO    by Abel Macias
+PRO    October 11th, 2019
+PRO 
+PRO    JavaScript funtions to control the presence of AWR points in the graphs
+PRO    and display the corresponding AWR report when clicked.
+PRO 
+PRO    These functions have to be included inside the drawChart() function.
+PRO  */
+PRO 
+PRO function selectHandler() {
+PRO     var selectedItem = programmaticChart.getChart().getSelection()[0];
+PRO     if (selectedItem) {
+PRO       var value = programmaticChart.getDataTable().getValue(selectedItem.row, 2);
+PRO       if (value != null) {
+PRO        var awrname = value.match(/(?:rac|\d)\_\d+\_\d+\_(?:max|med|min)\w{3,5}/);
+PRO        window.open('./edb360_show.html?awr=awrrpt_'+awrname)
+PRO       }
+PRO     }
+PRO   }
+PRO 
+PRO google.visualization.events.addListener(programmaticChart, 'select', selectHandler); 
+PRO 
+PRO toggleAnnotations = function() {
+PRO   if (programmaticChart.getOption('annotations.style') === 'line') {
+PRO         programmaticChart.setOption('annotations.style','point');
+PRO       } else {
+PRO         programmaticChart.setOption('annotations.style','line');
+PRO       }
+PRO   programmaticChart.draw();
+PRO }
+PRO 
+PRO toggleAWRPoint = function(id){
+PRO   switch(id){
+PRO     case 0: if ( racIdx   == 0 ) { racIdx= 1;    } else { racIdx= 0;    } break;
+PRO     case 1: if ( instIdx1 == 0 ) { instIdx1 = 1; } else { instIdx1 = 0; } break;
+PRO     case 2: if ( instIdx2 == 0 ) { instIdx2 = 1; } else { instIdx2 = 0; } break;
+PRO     case 3: if ( instIdx3 == 0 ) { instIdx3 = 1; } else { instIdx3 = 0; } break;
+PRO     case 4: if ( instIdx4 == 0 ) { instIdx4 = 1; } else { instIdx4 = 0; } break;
+PRO     case 5: if ( instIdx5 == 0 ) { instIdx5 = 1; } else { instIdx5 = 0; } break;
+PRO     case 6: if ( instIdx6 == 0 ) { instIdx6 = 1; } else { instIdx6 = 0; } break;
+PRO     case 7: if ( instIdx7 == 0 ) { instIdx7 = 1; } else { instIdx7 = 0; } break;
+PRO     case 8: if ( instIdx8 == 0 ) { instIdx8 = 1; } else { instIdx8 = 0; } break;
+PRO   }
+PRO   data=chartData.concat([]);
+PRO   if (racIdx > 0)   { data = data.concat(racData); }
+PRO   if (instIdx1 >0 ) { data = data.concat(instData1); }
+PRO   if (instIdx2 >0 ) { data = data.concat(instData2); }
+PRO   if (instIdx3 >0 ) { data = data.concat(instData3); }
+PRO   if (instIdx4 >0 ) { data = data.concat(instData4); }
+PRO   if (instIdx5 >0 ) { data = data.concat(instData5); }
+PRO   if (instIdx6 >0 ) { data = data.concat(instData6); }
+PRO   if (instIdx7 >0 ) { data = data.concat(instData7); }
+PRO   if (instIdx8 >0 ) { data = data.concat(instData8); }
+PRO   programmaticChart.setDataTable(google.visualization.arrayToDataTable(data));
+PRO   programmaticChart.draw();
+PRO }
+PRO 
+PRINT :AWRPointsIni
+PRO     }
+PRO    </script>
+PRO  </head>
+PRO  <body>
+PRO
+PRO<h1> &&edb360_conf_all_pages_icon. &&section_id..&&report_sequence.. &&title. <em>(&&main_table.)</em> &&edb360_conf_all_pages_logo. </h1>
+PRO
+PRO <br />
+PRO &&abstract.
+PRO &&abstract2.
+PRO <br />
+PRO
+PRINT :AWRPointsControls
+PRO    <div id="linechart" class="google-chart"></div>
+PRO
+
+-- footer
+PRO <br />
+PRO <font class="n">Notes:<br />1) drag to zoom, and right click to reset<br />2) up to &&history_days. days of awr history were considered</font>
+PRO <font class="n"><br />3) &&foot.</font>
+PRO <pre>
+SET LIN 80;
+DESC &&main_table.
+SET HEA OFF;
+SET LIN 32767;
+PRINT sql_text_display;
+SET HEA ON;
+--PRO &&row_count. rows selected.
+PRO &&row_num. rows selected.
+PRO </pre>
+
+@@edb360_0e_html_footer.sql
+SPO OFF;
+
+-- get time t1
+EXEC :get_time_t1 := DBMS_UTILITY.get_time;
+
+-- update log2
+SET HEA OFF;
+SPO &&edb360_log2..txt APP;
+SELECT TO_CHAR(SYSDATE, '&&edb360_date_format.')||' , '||
+       TO_CHAR((:get_time_t1 - :get_time_t0)/100, '999,999,990.00')||'s , rows:'||
+       --:row_count||' , &&section_id., &&main_table., &&edb360_prev_sql_id., -1, &&title_no_spaces., html , &&one_spool_filename._line_chart.html'
+       '&&row_num., &&section_id., &&main_table., &&edb360_prev_sql_id., -1, &&title_no_spaces., line , &&one_spool_filename._line_chart.html'
+  FROM DUAL
+/
+SPO OFF;
+SET HEA ON;
+
+-- zip
+HOS zip -mj &&edb360_zip_filename. &&edb360_output_directory.&&one_spool_filename._line_chart.html >> &&edb360_log3..txt
+
+SET TERM ON
+PRO Finished one line plus


### PR DESCRIPTION
The AWR Points Feature adds to the line graphs visual marks to identify the time the begin snapshot of the AWR Reports generated by section 7a.
To create this feature a new rendering script was created named 9e_one_line_chart_plus.
The "plus" is because this new rendering script will be used to add more features in future versions without the need to disturb the original 9e_one_line_chart. 
9e_pre-one will make a decision as to which script to use (line_chart XOR line_chart_plus ) depending if a new feature is enabled.
The feature is disabled by default. To enable, a (custom) config file should include : 

-- Plotting the points where AWR reports are taken by the edb360 
DEF edb360_conf_incl_plot_awr ='Y';  
 