### PR TITLE
add a list of database options to section 1a

### DIFF
--- a/sql/edb360_1a_configuration.sql
+++ b/sql/edb360_1a_configuration.sql
@@ -224,6 +224,18 @@ END;
 /
 @@edb360_9a_pre_one.sql
 
+DEF title = 'Options';
+DEF main_table = '&&v_view_prefix.OPTION';
+BEGIN
+  :sql_text := q'[
+SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
+       *
+  FROM &&v_object_prefix.option
+]';
+END;
+/
+@@edb360_9a_pre_one.sql
+
 DEF title = 'Database';
 DEF main_table = '&&v_view_prefix.DATABASE';
 BEGIN


### PR DESCRIPTION
I have added a new report to section 1a, pulling the contents from v$option. I hope I managed to do this properly, kindly check my addition and let me know if any changes are needed.