### PR TITLE
Consistent edb36/sqld360 call to the same custom config file

### DIFF
--- a/sql/aegcfg.sql
+++ b/sql/aegcfg.sql
@@ -29,3 +29,10 @@ DEF edb360_conf_max_hours = '24';
 DEF edb360_conf_incl_awr_diff_rpt = 'N';
 DEF edb360_conf_incl_plot_awr ='Y';
 DEF edb360_conf_series_selection ='Y';
+
+-- transfer options to sqld
+-- Do not modify unless you want different options for edb and sqld
+
+DEF sqld360_conf_incl_awr_diff_rpt = '&&edb360_conf_incl_awr_diff_rpt.';
+DEF sqld360_conf_incl_plot_awr ='&&edb360_conf_incl_plot_awr.';
+DEF sqld360_conf_series_selection ='&&edb360_conf_series_selection.';

--- a/sql/edb360_7b_sql_sample.sql
+++ b/sql/edb360_7b_sql_sample.sql
@@ -381,9 +381,9 @@ BEGIN
       update_log('SQLD360 rank:'||sql_rec.rank_num||' SQL_ID:'||sql_rec.sql_id||' TOP_type:'||sql_rec.top_type);
       put_line('PRO PRO prepares execution of sqld360');
       IF sql_rec.rank_num <= &&edb360_conf_sqld360_top_tc. THEN
-        put_line('INSERT INTO plan_table (id, statement_id, operation, options, object_node) SELECT '||sql_rec.rank_num||', ''SQLD360_SQLID'', '''||sql_rec.sql_id||''', ''&&call_sqld360_bitmask_tc.'', '''||sql_rec.pdb_name||''' FROM DUAL WHERE (DBMS_UTILITY.GET_TIME - :edb360_time0) / 100  <  :edb360_max_seconds;');
+        put_line('INSERT INTO plan_table (id, statement_id, operation, options, object_node, projection) SELECT '||sql_rec.rank_num||', ''SQLD360_SQLID'', '''||sql_rec.sql_id||''', ''&&call_sqld360_bitmask_tc.'', '''||sql_rec.pdb_name||''' , ''&&custom_config_filename.'' FROM DUAL WHERE (DBMS_UTILITY.GET_TIME - :edb360_time0) / 100  <  :edb360_max_seconds;');
       ELSE
-        put_line('INSERT INTO plan_table (id, statement_id, operation, options, object_node) SELECT '||sql_rec.rank_num||', ''SQLD360_SQLID'', '''||sql_rec.sql_id||''', ''&&call_sqld360_bitmask.'', '''||sql_rec.pdb_name||''' FROM DUAL WHERE (DBMS_UTILITY.GET_TIME - :edb360_time0) / 100  <  :edb360_max_seconds;');
+        put_line('INSERT INTO plan_table (id, statement_id, operation, options, object_node, projection) SELECT '||sql_rec.rank_num||', ''SQLD360_SQLID'', '''||sql_rec.sql_id||''', ''&&call_sqld360_bitmask.'', '''||sql_rec.pdb_name||''' , ''&&custom_config_filename.'' FROM DUAL WHERE (DBMS_UTILITY.GET_TIME - :edb360_time0) / 100  <  :edb360_max_seconds;');
       END IF;
     END IF;
   END LOOP;

--- a/sqld360.sql
+++ b/sqld360.sql
@@ -108,7 +108,7 @@ BEGIN
 
     -- this execution is from edb360, call SQLd360 several times passing the appropriare flag
     --  the DISTINCT here is to make sure we run SQLd360 once even though the SQL is top in multiple categories (e.g. signature and dbtime)
-    FOR i IN (SELECT operation, options, object_node
+    FOR i IN (SELECT operation, options, object_node, projection
                 FROM plan_table
                WHERE statement_id = 'SQLD360_SQLID'
                ORDER BY id) LOOP
@@ -151,7 +151,7 @@ BEGIN
        --  the code can switch back to CDB to update the right plan table with the file name
        put('DEF sqld360_container='''||container||'''');
 
-       put('@@&&skip_sqld360.sql/sqld360_0a_main.sql '||i.operation||' '||license||' NULL');
+       put('@@&&skip_sqld360.sql/sqld360_0a_main.sql '||i.operation||' '||license||' '||i.projection);
        put('HOS unzip -l &&sqld360_main_filename._&&sqld360_file_time.');
 
        -- the following code is to handle the timeout from eDB360


### PR DESCRIPTION
This change allows edb360 to call sqld360 with the same custom configuration file used to call edb360.