### PR TITLE
fix wrong result with planx.sql

### DIFF
--- a/sql/planx.sql
+++ b/sql/planx.sql
@@ -1134,6 +1134,7 @@ BEGIN
   	       AND h.sql_id = :sql_id
   	       AND h.current_obj# >= 0
   	       AND o.object_id(+) = h.current_obj#
+           AND h.wait_class in ('Application', 'Cluster', 'Concurrency', 'User I/O')
   	     UNION
   	    SELECT /*+ 
                FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.sn) 
@@ -1154,6 +1155,7 @@ BEGIN
   	       AND h.sql_id = :sql_id
   	       AND h.current_obj# >= 0
   	       AND o.object_id(+) = h.current_obj#
+           AND h.wait_class in ('Application', 'Cluster', 'Concurrency', 'User I/O')
   	    )
   	    SELECT 'TABLE', t.owner, t.table_name
   	      FROM dba_tab_statistics t, -- include fixed objects


### PR DESCRIPTION
# Pull request documentation

This pull request addresses a problem when calling `planx.sql`. As part of its output, `planx.sql` generates a list of tables referenced in the SQL statement it analyses. The report often returns more rows (=tables) than it should. Please refer to the test case for an example. If this pull request is accepted, a similar request will follow for `sqld360.sql`

## Test case

It is possible to reproduce the problem by running Swingbench. The test was generated using Swingbench 2.6.

### Steps to reproduce

To reproduce, run swingbench's Order Entry benchmark:

```
$ ./charbench -c ../configs/SOE_Client_Side.xml -u soe2 -cs //host/swingbench_srv -uc 10
```

Wait for 10 minutes for the application to leave a foot print in the shared pool.

### Test case

The following application query was selectede to demonstrate the problem with `planx.sql`

```sql
select sql_fulltext, executions from v$sql where sql_id = 'g1znkya370htg'

SQL_FULLTEXT
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
EXECUTIONS
----------
select   products.PRODUCT_ID,
              PRODUCT_NAME,
              PRODUCT_DESCRIPTION,
              CATEGORY_ID,
              WEIGHT_CLASS,
              WARRANTY_PERIOD,
              SUPPLIER_ID,
              PRODUCT_STATUS,
              LIST_PRICE,
              MIN_PRICE,
              CATALOG_URL,
              QUANTITY_ON_HAND
      from products,
      inventories
      where products.category_id = :1
      and inventories.product_id = products.product_id
      and inventories.warehouse_id = :2
      and rownum < 5
    887633
```

As per the statement, only PRODUCTS and INVENTORIES are referenced. `planx.sql` returns the tables touched by the query from line 1112 onwards:

```sql
var sql_id varchar2(20)
var dbid number
var license char(1)

exec :sql_id := 'g1znkya370htg'
exec :dbid := 49197792
exec :license := 'Y'

col owner for a30
col table_name for a30

WITH object AS (
  	    SELECT /*+ MATERIALIZE */
  	           object_owner owner, object_name name
  	      FROM gv$sql_plan
  	     WHERE inst_id IN (SELECT inst_id FROM gv$instance)
  	       AND sql_id = :sql_id
  	       AND object_owner IS NOT NULL
  	       AND object_name IS NOT NULL
  	     UNION
  	    SELECT object_owner owner, object_name name
  	      FROM dba_hist_sql_plan
  	     WHERE :license = 'Y'
  	       AND dbid = :dbid
  	       AND sql_id = :sql_id
  	       AND object_owner IS NOT NULL
  	       AND object_name IS NOT NULL
  	     UNION
  	    SELECT CASE h.current_obj# WHEN 0 THEN 'SYS' ELSE o.owner END owner, 
  	           CASE h.current_obj# WHEN 0 THEN 'UNDO' ELSE o.object_name END name
  	      FROM gv$active_session_history h,
  	           dba_objects o
  	     WHERE :license = 'Y'
  	       AND h.sql_id = :sql_id
  	       AND h.current_obj# >= 0
  	       AND o.object_id(+) = h.current_obj#
  	     UNION
  	    SELECT /*+ 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.sn) 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.ash) 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.evt) 
               USE_HASH(h.INT$DBA_HIST_ACT_SESS_HISTORY.sn h.INT$DBA_HIST_ACT_SESS_HISTORY.ash h.INT$DBA_HIST_ACT_SESS_HISTORY.evt)
               FULL(h.sn) 
               FULL(h.ash) 
               FULL(h.evt) 
               USE_HASH(h.sn h.ash h.evt)
               */
               CASE h.current_obj# WHEN 0 THEN 'SYS' ELSE o.owner END owner, 
  	           CASE h.current_obj# WHEN 0 THEN 'UNDO' ELSE o.object_name END name
  	      FROM dba_hist_active_sess_history h,
  	           dba_objects o
  	     WHERE :license = 'Y'
  	       AND h.dbid = :dbid
  	       AND h.sql_id = :sql_id
  	       AND h.current_obj# >= 0
  	       AND o.object_id(+) = h.current_obj#
  	    )
  	    SELECT 'TABLE', t.owner, t.table_name
  	      FROM dba_tab_statistics t, -- include fixed objects
  	           object o
  	     WHERE t.owner = o.owner
  	       AND t.table_name = o.name
  	     UNION
  	    SELECT 'TABLE', i.table_owner, i.table_name
  	      FROM dba_indexes i,
  	           object o
  	     WHERE i.owner = o.owner
  	       AND i.index_name = o.name;

'TABL OWNER                          TABLE_NAME
----- ------------------------------ ------------------------------
TABLE SOE2                           ADDRESSES
TABLE SOE2                           CARD_DETAILS
TABLE SOE2                           INVENTORIES
TABLE SOE2                           LOGON
TABLE SOE2                           PRODUCT_DESCRIPTIONS
TABLE SOE2                           PRODUCT_INFORMATION

6 rows selected.
```

There are rows unrelated to the query in the output, as you can see by calling `dbms_xplan`

### Expected result

The number of tables effectively touched as per `dbms_xplan`:

```sql
SQL> select * from table(dbms_xplan.display_cursor('g1znkya370htg', null, 'ALLSTATS LAST'));

PLAN_TABLE_OUTPUT
------------------------------------------------------------------------------------------------------------------------------------------------------
SQL_ID  g1znkya370htg, child number 0
-------------------------------------
select   products.PRODUCT_ID,                          PRODUCT_NAME,
                      PRODUCT_DESCRIPTION,
CATEGORY_ID,                          WEIGHT_CLASS,
     WARRANTY_PERIOD,                          SUPPLIER_ID,
             PRODUCT_STATUS,                          LIST_PRICE,
                   MIN_PRICE,                          CATALOG_URL,
                     QUANTITY_ON_HAND        from products,
     inventories                  where products.category_id = :1
            and inventories.product_id = products.product_id
      and inventories.warehouse_id = :2                   and rownum < 5

Plan hash value: 2393254267

--------------------------------------------------------------------------------
| Id  | Operation                              | Name                 | E-Rows |
--------------------------------------------------------------------------------
|   0 | SELECT STATEMENT                       |                      |        |
|*  1 |  COUNT STOPKEY                         |                      |        |
|   2 |   NESTED LOOPS                         |                      |      4 |
|   3 |    NESTED LOOPS OUTER                  |                      |      4 |
|   4 |     TABLE ACCESS BY INDEX ROWID BATCHED| PRODUCT_INFORMATION  |      4 |
|*  5 |      INDEX RANGE SCAN                  | PROD_CATEGORY_IX     |      4 |
|   6 |     TABLE ACCESS BY INDEX ROWID BATCHED| PRODUCT_DESCRIPTIONS |      1 |
|*  7 |      INDEX RANGE SCAN                  | PRD_DESC_PK          |      1 |
|   8 |    TABLE ACCESS BY INDEX ROWID         | INVENTORIES          |      1 |
|*  9 |     INDEX UNIQUE SCAN                  | INVENTORY_PK         |      1 |
--------------------------------------------------------------------------------

Predicate Information (identified by operation id):
---------------------------------------------------

   1 - filter(ROWNUM<5)
   5 - access("I"."CATEGORY_ID"=:1)
   7 - access("D"."PRODUCT_ID"="I"."PRODUCT_ID")
   9 - access("INVENTORIES"."PRODUCT_ID"="I"."PRODUCT_ID" AND
              "INVENTORIES"."WAREHOUSE_ID"=:2)

Note
-----
   - this is an adaptive plan
   - Warning: basic plan statistics not available. These are only collected when:
       * hint 'gather_plan_statistics' is used for the statement or
       * parameter 'statistics_level' is set to 'ALL', at session or system level


46 rows selected.
```

Only PRODUCT_INFORMATION, PRODUCT_DESCRIPTIONS and INVENTORIES should have been returned earlier.

## Suggested fix

The sub-queries against dba_hist_active_sess_history and v$active_session_history must be amended to only take valid waits into account. As per the [12.1 documentation](https://docs.oracle.com/database/121/REFRN/GUID-69CEA3A1-6C5E-43D6-982C-F353CD4B984C.htm):

```
CURRENT_OBJ#

NUMBER

Object ID of the object that the session is referencing. This information is only available if the session was waiting for application, cluster, concurrency, and user I/O wait events. Maps to V$SESSION.ROW_WAIT_OBJ#.
```

Checking the query in `planx.sql`, irrelevant events are not filtered:

```sql
SQL> r
  1  SELECT
  2      CASE h.current_obj# WHEN 0 THEN 'SYS' ELSE o.owner END owner,
  3      CASE h.current_obj# WHEN 0 THEN 'UNDO' ELSE o.object_name END name,
  4      h.event,
  5      h.wait_class,
  6      h.session_state
  7  FROM
  8      gv$active_session_history  h,
  9      dba_objects                o
 10  WHERE
 11          :license = 'Y'
 12      AND h.sql_id = :sql_id
 13      AND h.current_obj# >= 0
 14*     AND o.object_id (+) = h.current_obj#

OWNER      NAME                           EVENT                          WAIT_CLASS           SESSION
---------- ------------------------------ ------------------------------ -------------------- -------
SOE2       CARDDETAILS_CUST_IX                                                                ON CPU
SOE2       INVENTORIES                    db file scattered read         User I/O             WAITING
SOE2       INVENTORIES                    db file scattered read         User I/O             WAITING
SOE2       LOGON                                                                              ON CPU
SOE2       LOGON                                                                              ON CPU
SOE2       LOGON                                                                              ON CPU
SOE2       LOGON                                                                              ON CPU
SOE2       INVENTORY_PK                   db file scattered read         User I/O             WAITING
SOE2       INVENTORY_PK                   db file scattered read         User I/O             WAITING
SOE2       ADDRESS_CUST_IX                                                                    ON CPU

10 rows selected.

```

The suggestion is to change the query in `planx.sql` to read:

```SQL
WITH object AS (
  	    SELECT /*+ MATERIALIZE */
  	           object_owner owner, object_name name
  	      FROM gv$sql_plan
  	     WHERE inst_id IN (SELECT inst_id FROM gv$instance)
  	       AND sql_id = :sql_id
  	       AND object_owner IS NOT NULL
  	       AND object_name IS NOT NULL
  	     UNION
  	    SELECT object_owner owner, object_name name
  	      FROM dba_hist_sql_plan
  	     WHERE :license = 'Y'
  	       AND dbid = :dbid
  	       AND sql_id = :sql_id
  	       AND object_owner IS NOT NULL
  	       AND object_name IS NOT NULL
  	     UNION
  	    SELECT CASE h.current_obj# WHEN 0 THEN 'SYS' ELSE o.owner END owner, 
  	           CASE h.current_obj# WHEN 0 THEN 'UNDO' ELSE o.object_name END name
  	      FROM gv$active_session_history h,
  	           dba_objects o
  	     WHERE :license = 'Y'
  	       AND h.sql_id = :sql_id
  	       AND h.current_obj# >= 0
  	       AND o.object_id(+) = h.current_obj#
               AND h.wait_class in ('Application', 'Cluster', 'Concurrency', 'User I/O')
  	     UNION
  	    SELECT /*+ 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.sn) 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.ash) 
               FULL(h.INT$DBA_HIST_ACT_SESS_HISTORY.evt) 
               USE_HASH(h.INT$DBA_HIST_ACT_SESS_HISTORY.sn h.INT$DBA_HIST_ACT_SESS_HISTORY.ash h.INT$DBA_HIST_ACT_SESS_HISTORY.evt)
               FULL(h.sn) 
               FULL(h.ash) 
               FULL(h.evt) 
               USE_HASH(h.sn h.ash h.evt)
               */
               CASE h.current_obj# WHEN 0 THEN 'SYS' ELSE o.owner END owner, 
  	           CASE h.current_obj# WHEN 0 THEN 'UNDO' ELSE o.object_name END name
  	      FROM dba_hist_active_sess_history h,
  	           dba_objects o
  	     WHERE :license = 'Y'
  	       AND h.dbid = :dbid
  	       AND h.sql_id = :sql_id
  	       AND h.current_obj# >= 0
  	       AND o.object_id(+) = h.current_obj#
               AND h.wait_class in ('Application', 'Cluster', 'Concurrency', 'User I/O')
  	    )
  	    SELECT 'TABLE', t.owner, t.table_name
  	      FROM dba_tab_statistics t, -- include fixed objects
  	           object o
  	     WHERE t.owner = o.owner
  	       AND t.table_name = o.name
  	     UNION
  	    SELECT 'TABLE', i.table_owner, i.table_name
  	      FROM dba_indexes i,
  	           object o
  	     WHERE i.owner = o.owner
  	       AND i.index_name = o.name;
```

A quick test revealed the correct number of tables was returned:

```
SQL> /

'TABL OWNER      TABLE_NAME
----- ---------- ------------------------------
TABLE SOE2       INVENTORIES
TABLE SOE2       PRODUCT_DESCRIPTIONS
TABLE SOE2       PRODUCT_INFORMATION
```