### PR TITLE
Enhancements and Corrections to eDB360 section 4

### DIFF
--- a/sql/edb360_0b_pre.sql
+++ b/sql/edb360_0b_pre.sql
@@ -962,6 +962,7 @@ COL name CLE;
 COL value CLE;
 COL display_value CLE;
 COL update_comment CLE;
+COL cpu_load_threshold CLEAR
 SHOW PARAMETERS;
 SELECT 'Tool Execution Hours so far: '||ROUND((DBMS_UTILITY.GET_TIME - :edb360_main_time0) / 100 / 3600, 3) tool_exec_hours FROM DUAL
 /

--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -17,7 +17,7 @@ END;
 /
 @@&&skip_ver_le_11.edb360_9a_pre_one.sql
 
-DEF main_table = '&&cdb_awr_hist_prefix.SGASTAT';
+DEF main_table = '&&awr_hist_prefix.SGASTAT';
 DEF chartype = 'LineChart';
 DEF stacked = '';
 DEF vaxis = 'SGA Statistics in GBs';
@@ -43,7 +43,6 @@ WITH
 sgastat_denorm_1 AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        snap_id,
-	   &&skip_noncdb.con_id,
        dbid,
        instance_number,
        SUM(bytes) sga_total,
@@ -55,19 +54,17 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        SUM(CASE pool WHEN 'large pool' THEN bytes ELSE 0 END) large_pool,
        SUM(CASE pool WHEN 'java pool' THEN bytes ELSE 0 END) java_pool,
        SUM(CASE pool WHEN 'streams pool' THEN bytes ELSE 0 END) streams_pool
-  FROM &&cdb_awr_object_prefix.sgastat
+  FROM &&awr_object_prefix.sgastat
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND instance_number = @instance_number@
  GROUP BY
        snap_id,
-	   &&skip_noncdb.con_id,
        dbid,
        instance_number
 ), sgastat_denorm_2 AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        h1.snap_id,
-	   &&skip_noncdb.h1.con_id,
        h1.dbid,
        h1.instance_number,
        s1.begin_interval_time,
@@ -84,11 +81,10 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        h1.streams_pool
   FROM sgastat_denorm_1 h0,
        sgastat_denorm_1 h1,
-       &&cdb_awr_object_prefix.snapshot s0,
-       &&cdb_awr_object_prefix.snapshot s1
+       &&awr_object_prefix.snapshot s0,
+       &&awr_object_prefix.snapshot s1
  WHERE h1.snap_id = h0.snap_id + 1
    AND h1.dbid = h0.dbid
-   &&skip_noncdb.and h1.con_id = h0.con_id
    AND h1.instance_number = h0.instance_number
    AND s0.snap_id = h0.snap_id
    AND s0.dbid = h0.dbid
@@ -102,8 +98,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
    AND s1.startup_time = s0.startup_time
    AND s1.begin_interval_time > (s0.begin_interval_time + (1 / (24 * 60))) /* filter out snaps apart < 1 min */
 ), x as (
-SELECT &&skip_noncdb.con_id,
-       snap_id,
+SELECT snap_id,
        TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
        TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
        ROUND(SUM(sga_total) / POWER(2,30), 3) sga_total,
@@ -123,16 +118,12 @@ SELECT &&skip_noncdb.con_id,
        0 dummy_15
   FROM sgastat_denorm_2
  GROUP BY
-       &&skip_noncdb.con_id,
-	   snap_id
+       snap_id
 )
 SELECT x.*
-       &&skip_noncdb.,c.name con_name
 FROM   x
-       &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
  ORDER BY
-       &&skip_noncdb.x.con_id,
-	   x.snap_id
+       x.snap_id
 ]';
 END;
 /
@@ -201,6 +192,600 @@ EXEC :sql_text := REPLACE(:sql_text_backup, '@instance_number@', '8');
 @@&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
 
 
+--dmk begin SGASTAT per PDB per INSTANCE
+DEF main_table = '&&cdb_awr_hist_prefix.SGASTAT';
+
+COL con_id_01 NEW_V con_id_01;
+COL con_id_02 NEW_V con_id_02;
+COL con_id_03 NEW_V con_id_03;
+COL con_id_04 NEW_V con_id_04;
+COL con_id_05 NEW_V con_id_05;
+COL con_id_06 NEW_V con_id_06;
+COL con_id_07 NEW_V con_id_07;
+COL con_id_08 NEW_V con_id_08;
+COL con_id_09 NEW_V con_id_09;
+COL con_id_10 NEW_V con_id_10;
+COL con_id_11 NEW_V con_id_11;
+COL con_id_12 NEW_V con_id_12;
+COL con_id_13 NEW_V con_id_13;
+COL con_id_14 NEW_V con_id_14;
+COL con_id_15 NEW_V con_id_15;
+
+COL con_name_01 NEW_V con_name_01;
+COL con_name_02 NEW_V con_name_02;
+COL con_name_03 NEW_V con_name_03;
+COL con_name_04 NEW_V con_name_04;
+COL con_name_05 NEW_V con_name_05;
+COL con_name_06 NEW_V con_name_06;
+COL con_name_07 NEW_V con_name_07;
+COL con_name_08 NEW_V con_name_08;
+COL con_name_09 NEW_V con_name_09;
+COL con_name_10 NEW_V con_name_10;
+COL con_name_11 NEW_V con_name_11;
+COL con_name_12 NEW_V con_name_12;
+COL con_name_13 NEW_V con_name_13;
+COL con_name_14 NEW_V con_name_14;
+COL con_name_15 NEW_V con_name_15;
+
+DEF tit_01 = '';
+DEF tit_02 = '';
+DEF tit_03 = '';
+DEF tit_04 = '';
+DEF tit_05 = '';
+DEF tit_06 = '';
+DEF tit_07 = '';
+DEF tit_08 = '';
+DEF tit_09 = '';
+DEF tit_10 = '';
+DEF tit_11 = '';
+DEF tit_12 = '';
+DEF tit_13 = '';
+DEF tit_14 = '';
+DEF tit_15 = '';
+
+WITH x AS (
+SELECT con_id,
+       AVG(bytes) sga_total
+  FROM &&awr_object_prefix.sgastat
+ WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+   AND dbid = &&edb360_dbid.
+GROUP BY con_id
+), y AS (
+SELECT row_number() OVER (ORDER BY sga_total DESC) wrank,
+       x.con_id, 'PDB_'||x.con_id||'_'||c.name con_name
+FROM   x
+       &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
+), z AS (
+SELECT row_number() OVER (ORDER BY con_id) wrank,
+       y.con_id, y.con_name
+  FROM y
+ WHERE wrank <= 15
+)
+SELECT NVL(MAX(CASE wrank WHEN 01 THEN con_id END),-1) con_id_01,
+       NVL(MAX(CASE wrank WHEN 02 THEN con_id END),-1) con_id_02,
+       NVL(MAX(CASE wrank WHEN 03 THEN con_id END),-1) con_id_03,
+       NVL(MAX(CASE wrank WHEN 04 THEN con_id END),-1) con_id_04,
+       NVL(MAX(CASE wrank WHEN 05 THEN con_id END),-1) con_id_05,
+       NVL(MAX(CASE wrank WHEN 06 THEN con_id END),-1) con_id_06,
+       NVL(MAX(CASE wrank WHEN 07 THEN con_id END),-1) con_id_07,
+       NVL(MAX(CASE wrank WHEN 08 THEN con_id END),-1) con_id_08,
+       NVL(MAX(CASE wrank WHEN 09 THEN con_id END),-1) con_id_09,
+       NVL(MAX(CASE wrank WHEN 10 THEN con_id END),-1) con_id_10,
+       NVL(MAX(CASE wrank WHEN 11 THEN con_id END),-1) con_id_11,
+       NVL(MAX(CASE wrank WHEN 12 THEN con_id END),-1) con_id_12,
+       NVL(MAX(CASE wrank WHEN 13 THEN con_id END),-1) con_id_13,
+       NVL(MAX(CASE wrank WHEN 14 THEN con_id END),-1) con_id_14,
+       NVL(MAX(CASE wrank WHEN 15 THEN con_id END),-1) con_id_15,
+       NVL(MAX(CASE wrank WHEN 01 THEN con_name END),'DUMMY_01') con_name_01,
+       NVL(MAX(CASE wrank WHEN 02 THEN con_name END),'DUMMY_02') con_name_02,
+       NVL(MAX(CASE wrank WHEN 03 THEN con_name END),'DUMMY_03') con_name_03,
+       NVL(MAX(CASE wrank WHEN 04 THEN con_name END),'DUMMY_04') con_name_04,
+       NVL(MAX(CASE wrank WHEN 05 THEN con_name END),'DUMMY_05') con_name_05,
+       NVL(MAX(CASE wrank WHEN 06 THEN con_name END),'DUMMY_06') con_name_06,
+       NVL(MAX(CASE wrank WHEN 07 THEN con_name END),'DUMMY_07') con_name_07,
+       NVL(MAX(CASE wrank WHEN 08 THEN con_name END),'DUMMY_08') con_name_08,
+       NVL(MAX(CASE wrank WHEN 09 THEN con_name END),'DUMMY_09') con_name_09,
+       NVL(MAX(CASE wrank WHEN 10 THEN con_name END),'DUMMY_10') con_name_10,
+       NVL(MAX(CASE wrank WHEN 11 THEN con_name END),'DUMMY_11') con_name_11,
+       NVL(MAX(CASE wrank WHEN 12 THEN con_name END),'DUMMY_12') con_name_12,
+       NVL(MAX(CASE wrank WHEN 13 THEN con_name END),'DUMMY_13') con_name_13,
+       NVL(MAX(CASE wrank WHEN 14 THEN con_name END),'DUMMY_14') con_name_14,
+       NVL(MAX(CASE wrank WHEN 15 THEN con_name END),'DUMMY_15') con_name_15,
+       MAX(CASE wrank WHEN 01 THEN con_name END) tit_01,
+       MAX(CASE wrank WHEN 02 THEN con_name END) tit_02,
+       MAX(CASE wrank WHEN 03 THEN con_name END) tit_03,
+       MAX(CASE wrank WHEN 04 THEN con_name END) tit_04,
+       MAX(CASE wrank WHEN 05 THEN con_name END) tit_05,
+       MAX(CASE wrank WHEN 06 THEN con_name END) tit_06,
+       MAX(CASE wrank WHEN 07 THEN con_name END) tit_07,
+       MAX(CASE wrank WHEN 08 THEN con_name END) tit_08,
+       MAX(CASE wrank WHEN 09 THEN con_name END) tit_09,
+       MAX(CASE wrank WHEN 10 THEN con_name END) tit_10,
+       MAX(CASE wrank WHEN 11 THEN con_name END) tit_11,
+       MAX(CASE wrank WHEN 12 THEN con_name END) tit_12,
+       MAX(CASE wrank WHEN 13 THEN con_name END) tit_13,
+       MAX(CASE wrank WHEN 14 THEN con_name END) tit_14,
+       MAX(CASE wrank WHEN 15 THEN con_name END) tit_15
+  FROM z
+ WHERE wrank <= 15;
+
+DEF chartype = 'LineChart';
+DEF stacked = '';
+DEF vaxis = 'Total SGA Allocated (Gb) per PDB (GB)';
+DEF vbaseline = '';
+BEGIN
+  :sql_text_backup := q'[
+WITH
+sgastat_denorm_1 AS (
+SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
+       snap_id,
+       &&skip_noncdb.con_id,
+       dbid,
+       instance_number,
+       SUM(bytes) sga_total
+  FROM &&awr_object_prefix.sgastat
+ WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+   AND dbid = &&edb360_dbid.
+   AND instance_number = @instance_number@ @sgastat_criteria@
+ GROUP BY
+       snap_id,
+       &&skip_noncdb.con_id,
+       dbid,
+       instance_number
+), sgastat_denorm_2 AS (
+SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
+       h1.snap_id,
+       &&skip_noncdb.h1.con_id,
+       h1.dbid,
+       h1.instance_number,
+       s1.begin_interval_time,
+       s1.end_interval_time,
+       ROUND((CAST(s1.end_interval_time AS DATE) - CAST(s1.begin_interval_time AS DATE)) * 24 * 60 * 60) interval_secs,
+       h1.sga_total
+  FROM sgastat_denorm_1 h0,
+       sgastat_denorm_1 h1,
+       &&awr_object_prefix.snapshot s0,
+       &&awr_object_prefix.snapshot s1
+ WHERE h1.snap_id = h0.snap_id + 1
+   AND h1.dbid = h0.dbid
+   &&skip_noncdb.and h1.con_id = h0.con_id
+   AND h1.instance_number = h0.instance_number
+   AND s0.snap_id = h0.snap_id
+   AND s0.dbid = h0.dbid
+   AND s0.instance_number = h0.instance_number
+   AND s0.snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+   AND s0.dbid = &&edb360_dbid.
+   AND s1.snap_id = h1.snap_id
+   AND s1.dbid = h1.dbid
+   AND s1.instance_number = h1.instance_number
+   AND s1.snap_id = s0.snap_id + 1
+   AND s1.startup_time = s0.startup_time
+   AND s1.begin_interval_time > (s0.begin_interval_time + (1 / (24 * 60))) /* filter out snaps apart < 1 min */
+), x AS (
+SELECT snap_id, con_id,
+       TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
+       TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
+       ROUND(SUM(sga_total) / POWER(2,30), 3) sga_total
+  FROM sgastat_denorm_2
+ GROUP BY
+       snap_id, con_id
+), y AS (
+SELECT *
+  FROM x
+       PIVOT(AVG(NVL(sga_total,0)) FOR con_id IN(
+ &&con_id_01 &&con_name_01
+,&&con_id_02 &&con_name_02
+,&&con_id_03 &&con_name_03
+,&&con_id_04 &&con_name_04
+,&&con_id_05 &&con_name_05
+,&&con_id_06 &&con_name_06
+,&&con_id_07 &&con_name_07
+,&&con_id_08 &&con_name_08
+,&&con_id_09 &&con_name_09
+,&&con_id_10 &&con_name_10
+,&&con_id_11 &&con_name_11
+,&&con_id_12 &&con_name_12
+,&&con_id_13 &&con_name_13
+,&&con_id_14 &&con_name_14
+,&&con_id_15 &&con_name_15
+))
+)
+select snap_id, begin_time, end_time
+, NVL(&&con_name_01,0) &&con_name_01
+, NVL(&&con_name_02,0) &&con_name_02
+, NVL(&&con_name_03,0) &&con_name_03
+, NVL(&&con_name_04,0) &&con_name_04
+, NVL(&&con_name_05,0) &&con_name_05
+, NVL(&&con_name_06,0) &&con_name_06
+, NVL(&&con_name_07,0) &&con_name_07
+, NVL(&&con_name_08,0) &&con_name_08
+, NVL(&&con_name_09,0) &&con_name_09
+, NVL(&&con_name_10,0) &&con_name_10
+, NVL(&&con_name_11,0) &&con_name_11
+, NVL(&&con_name_12,0) &&con_name_12
+, NVL(&&con_name_13,0) &&con_name_13
+, NVL(&&con_name_14,0) &&con_name_14
+, NVL(&&con_name_15,0) &&con_name_15
+from y
+ORDER BY snap_id
+]';
+END;
+/
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Cluster';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := (REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+
+@@&&skip_noncdb.&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 1';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '1');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 2';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '2');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 3';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '3');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 4';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '4');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 5';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '5');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 6';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '6');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 7';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '7');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total SGA Allocated (Gb) per PDB for Instance 8';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '8');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', '');
+@@&&skip_noncdb.&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+
+
+DEF skip_lch = '';
+DEF title = 'Total Shared Pool Allocated (Gb) per PDB for Cluster';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := (REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+
+@@&&skip_noncdb.&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 1';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '1');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 2';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '2');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 3';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '3');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 4';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '4');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 5';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '5');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 6';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '6');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 7';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '7');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Shared Pool Allocated (Gb) per PDB for Instance 8';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '8');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''shared pool''');
+@@&&skip_noncdb.&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+
+
+
+DEF skip_lch = '';
+DEF title = 'Total Large Pool Allocated (Gb) per PDB for Cluster';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := (REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+
+@@&&skip_noncdb.&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 1';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '1');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 2';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '2');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 3';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '3');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 4';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '4');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 5';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '5');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 6';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '6');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 7';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '7');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Large Pool Allocated (Gb) per PDB for Instance 8';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '8');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''large pool''');
+@@&&skip_noncdb.&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Total Java Pool Allocated (Gb) per PDB for Cluster';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := (REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+
+@@&&skip_noncdb.&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 1';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '1');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 2';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '2');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 3';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '3');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 4';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '4');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 5';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '5');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 6';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '6');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 7';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '7');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Java Pool Allocated (Gb) per PDB for Instance 8';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '8');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''java pool''');
+@@&&skip_noncdb.&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Cluster';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := (REPLACE(:sql_text_backup, '@instance_number@', 'instance_number');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+
+@@&&skip_noncdb.&&is_single_instance.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 1';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '1');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst1.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 2';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '2');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst2.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 3';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '3');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst3.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 4';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '4');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst4.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 5';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '5');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst5.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 6';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '6');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst6.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 7';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '7');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst7.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+DEF skip_lch = '';
+DEF title = 'Streams Pool Allocated (Gb) per PDB for Instance 8';
+DEF abstract = '&&abstract_uom.';
+DEF foot = 'Does not include Free SGA Memory Available. For memory pools resize review Memory Statistics reports instead.'
+EXEC :sql_text_backup2 := REPLACE(:sql_text_backup, '@instance_number@', '8');
+EXEC :sql_text := REPLACE(:sql_text_backup2, '@sgastat_criteria@', 'AND pool = ''streams pool''');
+@@&&skip_noncdb.&&skip_inst8.&&skip_diagnostics.edb360_9a_pre_one.sql
+
+--dmk end SGASTAT per PDB per INSTANCE
+
+
 
 -- Find subpools anywhere in the cluster that have the largest changes.
 -- 1st Grouped by Instance because the variances happen inside each instance only.
@@ -219,7 +804,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        name,
        stddev(bytes) standard_dev
-  FROM &&cdb_awr_object_prefix.sgastat
+  FROM &&awr_object_prefix.sgastat
  WHERE pool='shared pool'
    AND snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -278,7 +863,7 @@ SELECT /*+ &&sq_fact_hints. */
        instance_number,
        name,
        stddev(bytes) standard_dev
-  FROM &&cdb_awr_object_prefix.sgastat
+  FROM &&awr_object_prefix.sgastat
  WHERE pool='shared pool'
    AND name <>'free memory'
    AND snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -376,24 +961,21 @@ BEGIN
 WITH
 sgastat_denorm_1 AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
-       &&skip_noncdb.con_id,
        snap_id,
        dbid,
        instance_number,
        SUM(bytes) allocated
-  FROM &&cdb_awr_object_prefix.sgastat
+  FROM &&awr_object_prefix.sgastat
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND pool = 'shared pool'
    AND @filter_predicate@
  GROUP BY
-       &&skip_noncdb.con_id,
        snap_id,
        dbid,
        instance_number
 ), sgastat_denorm_2 AS (
 SELECT /*+ &&sq_fact_hints. */
-       &&skip_noncdb.h1.con_id,
        h1.snap_id,
        h1.dbid,
        h1.instance_number,
@@ -403,10 +985,9 @@ SELECT /*+ &&sq_fact_hints. */
        h1.allocated
   FROM sgastat_denorm_1 h0,
        sgastat_denorm_1 h1,
-       &&cdb_awr_object_prefix.snapshot s0,
-       &&cdb_awr_object_prefix.snapshot s1
+       &&awr_object_prefix.snapshot s0,
+       &&awr_object_prefix.snapshot s1
  WHERE h1.snap_id = h0.snap_id + 1
-   &&skip_noncdb.AND h1.con_id = h0.con_id
    AND h1.dbid = h0.dbid
    AND h1.instance_number = h0.instance_number
    AND s0.snap_id = h0.snap_id
@@ -421,8 +1002,7 @@ SELECT /*+ &&sq_fact_hints. */
    AND s1.startup_time = s0.startup_time
    AND s1.begin_interval_time > (s0.begin_interval_time + (1 / (24 * 60))) /* filter out snaps apart < 1 min */
 )
-SELECT &&skip_noncdb.con_id,
-       snap_id,
+SELECT snap_id,
        TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
        TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
        0 dummy_01, --ROUND(SUM(CASE instance_number WHEN 1 THEN allocated ELSE 0 END)/POWER(2,20), 3) inst_01,
@@ -442,11 +1022,9 @@ SELECT &&skip_noncdb.con_id,
        0 dummy_15
   FROM sgastat_denorm_2
  GROUP BY
-       &&skip_noncdb.con_id,
-	   snap_id
+       snap_id
  ORDER BY
-       &&skip_noncdb.con_id,
-	   snap_id
+       snap_id
 ]';
 
  :sql_text_backup:=(CASE WHEN '&&inst1_present' IS NOT NULL THEN REPLACE(:sql_text_backup,'0 dummy_01, --','') ELSE :sql_text_backup END);
@@ -564,7 +1142,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        name subpool,
        instance_number,
        SUM(bytes) allocated
-  FROM &&cdb_awr_object_prefix.sgastat
+  FROM &&awr_object_prefix.sgastat
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND pool = 'shared pool'
@@ -577,9 +1155,9 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number
 ), sgastat_denorm_2 AS (
 SELECT /*+ &&sq_fact_hints. */
-       &&skip_noncdb.h1.con_id,
        h1.snap_id,
        h1.dbid,
+       &&skip_noncdb.h1.con_id,
        h1.subpool,
        s1.begin_interval_time,
        s1.end_interval_time,
@@ -587,8 +1165,8 @@ SELECT /*+ &&sq_fact_hints. */
        h1.allocated
   FROM sgastat_denorm_1 h0,
        sgastat_denorm_1 h1,
-       &&cdb_awr_object_prefix.snapshot s0,
-       &&cdb_awr_object_prefix.snapshot s1
+       &&awr_object_prefix.snapshot s0,
+       &&awr_object_prefix.snapshot s1
  WHERE h1.snap_id = h0.snap_id + 1
    &&skip_noncdb. AND h1.con_id = h0.con_id
    AND h1.dbid = h0.dbid
@@ -606,8 +1184,7 @@ SELECT /*+ &&sq_fact_hints. */
    AND s1.startup_time = s0.startup_time
    AND s1.begin_interval_time > (s0.begin_interval_time + (1 / (24 * 60))) /* filter out snaps apart < 1 min */
 )
-SELECT &&skip_noncdb.con_id,
-       snap_id,
+SELECT snap_id,
        TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
        TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
        ROUND(SUM(CASE subpool WHEN 'free memory' THEN allocated ELSE 0 END)/POWER(2,20), 3) free_memory,
@@ -630,11 +1207,9 @@ SELECT &&skip_noncdb.con_id,
        0 dummy_13
   FROM sgastat_denorm_2
  GROUP BY
-       &&skip_noncdb.con_id,
-	   snap_id
+       snap_id
  ORDER BY
-       &&skip_noncdb.con_id,
-	   snap_id
+       snap_id
 ]';
 
  :sql_text_backup:=(CASE WHEN '&&subpool_02.' IS NOT NULL THEN REPLACE(:sql_text_backup,'0 dummy_02, --','') ELSE :sql_text_backup END);

--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -243,9 +243,10 @@ DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
 
+REM 14.7.2020 dmk changed from AVG() to SUM()
 WITH x AS (
 SELECT con_id,
-       AVG(bytes) sga_total
+       SUM(bytes) sga_total
   FROM &&awr_object_prefix.sgastat
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.

--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -243,7 +243,6 @@ DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
 
-REM 14.7.2020 dmk changed from AVG() to SUM()
 WITH x AS (
 SELECT con_id,
        SUM(bytes) sga_total

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -261,7 +261,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * snap_wait_count) snap_wait_time_milli,
        SUM(snap_wait_count) snap_wait_count
   FROM histogram
- WHERE wait_count_this_snap >= 0
+ WHERE snap_wait_count >= 0
  GROUP BY
        snap_id,
        dbid

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -214,7 +214,7 @@ COL recovery NEW_V recovery;
 SELECT CHR(38)||' recovery' recovery FROM DUAL;
 -- this above is to handle event "RMAN backup & recovery I/O"
 
-
+--dmk 1.7.2020 added to trend latencies of 15 wait events
 
 DEF skip_lch = '';
 DEF title = 'Average Latency of Top 15 events';
@@ -238,7 +238,7 @@ DEF tit_14 = '&&event_name_14.';
 DEF tit_15 = '&&event_name_15.';
 
 BEGIN
-  :sql_text_backup := q'[
+  :sql_text := q'[
 WITH
 s AS ( /*min begin/end times for each snap across all instances*/
 SELECT dbid, snap_id,
@@ -343,7 +343,7 @@ DEF tit_15 = '';
 --removed group by instance, and sum per instance in final query.
 
 BEGIN
-  :sql_text := q'[
+  :sql_text_backup := q'[
 WITH
 histogram AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -242,21 +242,21 @@ DEF tit_13 = '&&event_name_13.';
 DEF tit_14 = '&&event_name_14.';
 DEF tit_15 = '&&event_name_15.';
 
-COL event_heading_01 NEW_V event_heading_01
-COL event_heading_02 NEW_V event_heading_02
-COL event_heading_03 NEW_V event_heading_03
-COL event_heading_04 NEW_V event_heading_04
-COL event_heading_05 NEW_V event_heading_05
-COL event_heading_06 NEW_V event_heading_06
-COL event_heading_07 NEW_V event_heading_07
-COL event_heading_08 NEW_V event_heading_08
-COL event_heading_09 NEW_V event_heading_09
-COL event_heading_10 NEW_V event_heading_10
-COL event_heading_11 NEW_V event_heading_11
-COL event_heading_12 NEW_V event_heading_12
-COL event_heading_13 NEW_V event_heading_13
-COL event_heading_14 NEW_V event_heading_14
-COL event_heading_15 NEW_V event_heading_15
+COL event_heading_01 NEW_V event_heading_01 HEADING '"&&event_name_01"' FORMAT 999,999.999
+COL event_heading_02 NEW_V event_heading_02 HEADING '"&&event_name_02"' FORMAT 999,999.999
+COL event_heading_03 NEW_V event_heading_03 HEADING '"&&event_name_03"' FORMAT 999,999.999
+COL event_heading_04 NEW_V event_heading_04 HEADING '"&&event_name_04"' FORMAT 999,999.999
+COL event_heading_05 NEW_V event_heading_05 HEADING '"&&event_name_05"' FORMAT 999,999.999
+COL event_heading_06 NEW_V event_heading_06 HEADING '"&&event_name_06"' FORMAT 999,999.999
+COL event_heading_07 NEW_V event_heading_07 HEADING '"&&event_name_07"' FORMAT 999,999.999
+COL event_heading_08 NEW_V event_heading_08 HEADING '"&&event_name_08"' FORMAT 999,999.999
+COL event_heading_09 NEW_V event_heading_09 HEADING '"&&event_name_09"' FORMAT 999,999.999
+COL event_heading_10 NEW_V event_heading_10 HEADING '"&&event_name_10"' FORMAT 999,999.999
+COL event_heading_11 NEW_V event_heading_11 HEADING '"&&event_name_11"' FORMAT 999,999.999
+COL event_heading_12 NEW_V event_heading_12 HEADING '"&&event_name_12"' FORMAT 999,999.999
+COL event_heading_13 NEW_V event_heading_13 HEADING '"&&event_name_13"' FORMAT 999,999.999
+COL event_heading_14 NEW_V event_heading_14 HEADING '"&&event_name_14"' FORMAT 999,999.999
+COL event_heading_15 NEW_V event_heading_15 HEADING '"&&event_name_15"' FORMAT 999,999.999
 
 SELECT REGEXP_REPLACE('&&event_name_01','[^A-Za-z0-9]+','_') event_heading_01
 ,      REGEXP_REPLACE('&&event_name_02','[^A-Za-z0-9]+','_') event_heading_02

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -235,6 +235,10 @@ DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
 
+REM dmk 1.7.2020 - removed wait_class_id from analytic partition by clause
+REM switched to cumulative average waited by number of events counted instead of average of equally weighted averages, 
+REM removed group by instance, and sum per instance in final query.
+
 BEGIN
   :sql_text_backup := q'[
 WITH
@@ -244,7 +248,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) snap_wait_count
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -254,23 +258,21 @@ average AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        snap_id,
        dbid,
-       instance_number,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/SUM(wait_count_this_snap) avg_wait_time_milli
+       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * snap_wait_count) snap_wait_time_milli,
+       SUM(snap_wait_count) snap_wait_count
   FROM histogram
  WHERE wait_count_this_snap >= 0
  GROUP BY
        snap_id,
-       dbid,
-       instance_number
-HAVING SUM(wait_count_this_snap) > 0
+       dbid
+--HAVING SUM(wait_count_this_snap) > 0
 ),
 average_average AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        a.snap_id,
        a.dbid,
-       a.instance_number,
-       MIN(a.avg_wait_time_milli) avg_wait_time_milli,
-       AVG(b.avg_wait_time_milli) avg_avg_wait_time_milli
+       MIN(a.snap_wait_time_milli/NULLIF(a.snap_wait_count,0)) avg_wait_time_milli,
+       SUM(b.snap_wait_time_milli)/NULLIF(SUM(b.snap_wait_count),0) avg_avg_wait_time_milli
   FROM average a,
        average b
  WHERE b.snap_id         <= a.snap_id
@@ -278,27 +280,34 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
    AND b.instance_number  = a.instance_number
  GROUP BY
        a.snap_id,
-       a.dbid,
-       a.instance_number
+       a.dbid
 ),
-per_inst AS (
+s AS ( /*min begin/end times for each snap across all instances*/
+SELECT dbid, snap_id,
+       MIN(begin_interval_time) begin_interval_time,
+       MIN(end_interval_time) end_interval_time
+  FROM dba_hist_snapshot s
+ WHERE snap_id BETWEEN &&begin_snap AND &&end_snap
+   AND dbid = &&dbid
+GROUP BY dbid, snap_id
+), 
+per_snap AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        h.snap_id,
        s.begin_interval_time,
        s.end_interval_time,
        h.avg_wait_time_milli,
        h.avg_avg_wait_time_milli
-  FROM average_average   h,
-       &&awr_object_prefix.snapshot s
+  FROM average_average h,
+       s
  WHERE s.snap_id         = h.snap_id
    AND s.dbid            = h.dbid
-   AND s.instance_number = h.instance_number
 )
 SELECT snap_id,
-       TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
-       TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
-       ROUND(SUM(avg_wait_time_milli), 3) avg_latency_ms,
-       ROUND(SUM(avg_avg_wait_time_milli), 3) latency_trend_ms,
+       TO_CHAR(begin_interval_time, 'YYYY-MM-DD HH24:MI:SS') begin_time,
+       TO_CHAR(end_interval_time, 'YYYY-MM-DD HH24:MI:SS') end_time,
+       ROUND(avg_wait_time_milli, 3) avg_latency_ms,
+       ROUND(avg_avg_wait_time_milli, 3) latency_trend_ms
        0 dummy_03,
        0 dummy_04,
        0 dummy_05,
@@ -312,9 +321,7 @@ SELECT snap_id,
        0 dummy_13,
        0 dummy_14,
        0 dummy_15
-  FROM per_inst
- GROUP BY
-       snap_id
+  FROM per_snap
  ORDER BY
        snap_id
 ]';
@@ -324,168 +331,168 @@ END;
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_01. "&&event_name_01." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_01.'') AND event_name = TRIM(''&&event_name_01.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_02. "&&event_name_02." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_02.'') AND event_name = TRIM(''&&event_name_02.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_03. "&&event_name_03." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_03.'') AND event_name = TRIM(''&&event_name_03.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_04. "&&event_name_04." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_04.'') AND event_name = TRIM(''&&event_name_04.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_05. "&&event_name_05." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_05.'') AND event_name = TRIM(''&&event_name_05.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_06. "&&event_name_06." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_06.'') AND event_name = TRIM(''&&event_name_06.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_07. "&&event_name_07." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_07.'') AND event_name = TRIM(''&&event_name_07.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_08. "&&event_name_08." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_08.'') AND event_name = TRIM(''&&event_name_08.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_09. "&&event_name_09." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_09.'') AND event_name = TRIM(''&&event_name_09.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_10. "&&event_name_10." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_10.'') AND event_name = TRIM(''&&event_name_10.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_11. "&&event_name_11." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_11.'') AND event_name = TRIM(''&&event_name_11.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_12. "&&event_name_12." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_12.'') AND event_name = TRIM(''&&event_name_12.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_13. "&&event_name_13." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_13.'') AND event_name = TRIM(''&&event_name_13.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_14. "&&event_name_14." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_14.'') AND event_name = TRIM(''&&event_name_14.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_15. "&&event_name_15." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_15.'') AND event_name = TRIM(''&&event_name_15.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_16. "&&event_name_16." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_16.'') AND event_name = TRIM(''&&event_name_16.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_17. "&&event_name_17." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_17.'') AND event_name = TRIM(''&&event_name_17.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_18. "&&event_name_18." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_18.'') AND event_name = TRIM(''&&event_name_18.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_19. "&&event_name_19." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_19.'') AND event_name = TRIM(''&&event_name_19.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_20. "&&event_name_20." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_20.'') AND event_name = TRIM(''&&event_name_20.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_21. "&&event_name_21." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_21.'') AND event_name = TRIM(''&&event_name_21.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_22. "&&event_name_22." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_22.'') AND event_name = TRIM(''&&event_name_22.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_23. "&&event_name_23." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_23.'') AND event_name = TRIM(''&&event_name_23.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_24. "&&event_name_24." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_24.'') AND event_name = TRIM(''&&event_name_24.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -220,6 +220,11 @@ DEF skip_lch = '';
 DEF title = 'Average Latency of Top 15 events';
 DEF abstract = ''
 DEF vaxis = 'Average Latency in milliseconds';
+DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
+DEF vbaseline = '';
+DEF chartype = 'LineChart';
+DEF stacked = '';
+
 
 DEF tit_01 = '&&event_name_01.';
 DEF tit_02 = '&&event_name_02.';
@@ -236,6 +241,39 @@ DEF tit_12 = '&&event_name_12.';
 DEF tit_13 = '&&event_name_13.';
 DEF tit_14 = '&&event_name_14.';
 DEF tit_15 = '&&event_name_15.';
+
+COL event_heading_01 NEW_V event_heading_01
+COL event_heading_02 NEW_V event_heading_02
+COL event_heading_03 NEW_V event_heading_03
+COL event_heading_04 NEW_V event_heading_04
+COL event_heading_05 NEW_V event_heading_05
+COL event_heading_06 NEW_V event_heading_06
+COL event_heading_07 NEW_V event_heading_07
+COL event_heading_08 NEW_V event_heading_08
+COL event_heading_09 NEW_V event_heading_09
+COL event_heading_10 NEW_V event_heading_10
+COL event_heading_11 NEW_V event_heading_11
+COL event_heading_12 NEW_V event_heading_12
+COL event_heading_13 NEW_V event_heading_13
+COL event_heading_14 NEW_V event_heading_14
+COL event_heading_15 NEW_V event_heading_15
+
+SELECT REPLACE('&&event_name_01',' ','_') event_heading_01
+,      REPLACE('&&event_name_02',' ','_') event_heading_02
+,      REPLACE('&&event_name_03',' ','_') event_heading_03
+,      REPLACE('&&event_name_04',' ','_') event_heading_04
+,      REPLACE('&&event_name_05',' ','_') event_heading_05
+,      REPLACE('&&event_name_06',' ','_') event_heading_06
+,      REPLACE('&&event_name_07',' ','_') event_heading_07
+,      REPLACE('&&event_name_08',' ','_') event_heading_08
+,      REPLACE('&&event_name_09',' ','_') event_heading_09
+,      REPLACE('&&event_name_10',' ','_') event_heading_10
+,      REPLACE('&&event_name_11',' ','_') event_heading_11
+,      REPLACE('&&event_name_12',' ','_') event_heading_12
+,      REPLACE('&&event_name_13',' ','_') event_heading_13
+,      REPLACE('&&event_name_14',' ','_') event_heading_14
+,      REPLACE('&&event_name_15',' ','_') event_heading_15
+  FROM DUAL;
 
 BEGIN
   :sql_text := q'[
@@ -291,21 +329,21 @@ SELECT *
   FROM per_snap
 PIVOT (
   AVG(avg_wait_time_milli) FOR event_name IN(
- '&&event_name_01' 
-,'&&event_name_02' 
-,'&&event_name_03' 
-,'&&event_name_04' 
-,'&&event_name_05' 
-,'&&event_name_06' 
-,'&&event_name_07' 
-,'&&event_name_08' 
-,'&&event_name_09' 
-,'&&event_name_10' 
-,'&&event_name_11' 
-,'&&event_name_12' 
-,'&&event_name_13' 
-,'&&event_name_14' 
-,'&&event_name_15' 
+ '&&event_name_01' &&event_heading_01
+,'&&event_name_02' &&event_heading_02
+,'&&event_name_03' &&event_heading_03
+,'&&event_name_04' &&event_heading_04
+,'&&event_name_05' &&event_heading_05
+,'&&event_name_06' &&event_heading_06
+,'&&event_name_07' &&event_heading_07
+,'&&event_name_08' &&event_heading_08
+,'&&event_name_09' &&event_heading_09
+,'&&event_name_10' &&event_heading_10
+,'&&event_name_11' &&event_heading_11
+,'&&event_name_12' &&event_heading_12
+,'&&event_name_13' &&event_heading_13
+,'&&event_name_14' &&event_heading_14
+,'&&event_name_15' &&event_heading_15
 ))
 ORDER BY snap_id
 ]';

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -277,7 +277,6 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        average b
  WHERE b.snap_id         <= a.snap_id
    AND b.dbid             = a.dbid
-   AND b.instance_number  = a.instance_number
  GROUP BY
        a.snap_id,
        a.dbid

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -344,7 +344,7 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
 SELECT * 
   FROM per_snap
 PIVOT (
-  AVG(avg_wait_time_milli) FOR event_name IN(
+  AVG(NVL(avg_wait_time_milli,0)) FOR event_name IN(
  '&&event_name_01' &&event_heading_01
 ,'&&event_name_02' &&event_heading_02
 ,'&&event_name_03' &&event_heading_03

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -275,21 +275,21 @@ SELECT REGEXP_REPLACE('&&event_name_01','[^A-Za-z0-9]+','_') event_heading_01
 ,      REGEXP_REPLACE('&&event_name_15','[^A-Za-z0-9]+','_') event_heading_15
   FROM DUAL;
 
-COL &&event_heading_01 HEADING '"&&event_name_01"' FORMAT 999,999.999
-COL &&event_heading_02 HEADING '"&&event_name_02"' FORMAT 999,999.999
-COL &&event_heading_03 HEADING '"&&event_name_03"' FORMAT 999,999.999
-COL &&event_heading_04 HEADING '"&&event_name_04"' FORMAT 999,999.999
-COL &&event_heading_05 HEADING '"&&event_name_05"' FORMAT 999,999.999
-COL &&event_heading_06 HEADING '"&&event_name_06"' FORMAT 999,999.999
-COL &&event_heading_07 HEADING '"&&event_name_07"' FORMAT 999,999.999
-COL &&event_heading_08 HEADING '"&&event_name_08"' FORMAT 999,999.999
-COL &&event_heading_09 HEADING '"&&event_name_09"' FORMAT 999,999.999
-COL &&event_heading_10 HEADING '"&&event_name_10"' FORMAT 999,999.999
-COL &&event_heading_11 HEADING '"&&event_name_11"' FORMAT 999,999.999
-COL &&event_heading_12 HEADING '"&&event_name_12"' FORMAT 999,999.999
-COL &&event_heading_13 HEADING '"&&event_name_13"' FORMAT 999,999.999
-COL &&event_heading_14 HEADING '"&&event_name_14"' FORMAT 999,999.999
-COL &&event_heading_15 HEADING '"&&event_name_15"' FORMAT 999,999.999
+COL &&event_heading_01 HEADING '&&event_name_01' FORMAT 999,999.999
+COL &&event_heading_02 HEADING '&&event_name_02' FORMAT 999,999.999
+COL &&event_heading_03 HEADING '&&event_name_03' FORMAT 999,999.999
+COL &&event_heading_04 HEADING '&&event_name_04' FORMAT 999,999.999
+COL &&event_heading_05 HEADING '&&event_name_05' FORMAT 999,999.999
+COL &&event_heading_06 HEADING '&&event_name_06' FORMAT 999,999.999
+COL &&event_heading_07 HEADING '&&event_name_07' FORMAT 999,999.999
+COL &&event_heading_08 HEADING '&&event_name_08' FORMAT 999,999.999
+COL &&event_heading_09 HEADING '&&event_name_09' FORMAT 999,999.999
+COL &&event_heading_10 HEADING '&&event_name_10' FORMAT 999,999.999
+COL &&event_heading_11 HEADING '&&event_name_11' FORMAT 999,999.999
+COL &&event_heading_12 HEADING '&&event_name_12' FORMAT 999,999.999
+COL &&event_heading_13 HEADING '&&event_name_13' FORMAT 999,999.999
+COL &&event_heading_14 HEADING '&&event_name_14' FORMAT 999,999.999
+COL &&event_heading_15 HEADING '&&event_name_15' FORMAT 999,999.999
 
 BEGIN
   :sql_text := q'[
@@ -320,7 +320,7 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
        dbid,
        snap_id,
        event_name,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/NULLIF(SUM(wait_count_this_snap),0) avg_wait_time_milli
+       ROUND(SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/NULLIF(SUM(wait_count_this_snap),0),3) avg_wait_time_milli
   FROM histogram
  WHERE wait_count_this_snap >= 0
  GROUP BY

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -235,6 +235,9 @@ DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
 
+REM dmk 1.7.2020 - removed wait_class_id from analytic partition by clause
+REM switched to cumulative average waited by number of events counted instead of average of equally weighted averages, 
+REM removed group by instance, and sum per instance in final query.
 BEGIN
   :sql_text_backup := q'[
 WITH
@@ -244,7 +247,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) snap_wait_count
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -254,23 +257,21 @@ average AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        snap_id,
        dbid,
-       instance_number,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/SUM(wait_count_this_snap) avg_wait_time_milli
+       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * snap_wait_count) snap_wait_time_milli,
+       SUM(snap_wait_count) snap_wait_count
   FROM histogram
  WHERE wait_count_this_snap >= 0
  GROUP BY
        snap_id,
-       dbid,
-       instance_number
-HAVING SUM(wait_count_this_snap) > 0
+       dbid
+--HAVING SUM(wait_count_this_snap) > 0
 ),
 average_average AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        a.snap_id,
        a.dbid,
-       a.instance_number,
-       MIN(a.avg_wait_time_milli) avg_wait_time_milli,
-       AVG(b.avg_wait_time_milli) avg_avg_wait_time_milli
+       MIN(a.snap_wait_time_milli/NULLIF(a.snap_wait_count,0)) avg_wait_time_milli,
+       SUM(b.snap_wait_time_milli)/NULLIF(SUM(b.snap_wait_count),0) avg_avg_wait_time_milli
   FROM average a,
        average b
  WHERE b.snap_id         <= a.snap_id
@@ -278,27 +279,34 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
    AND b.instance_number  = a.instance_number
  GROUP BY
        a.snap_id,
-       a.dbid,
-       a.instance_number
+       a.dbid
 ),
-per_inst AS (
+s AS ( /*min begin/end times for each snap across all instances*/
+SELECT dbid, snap_id,
+       MIN(begin_interval_time) begin_interval_time,
+       MIN(end_interval_time) end_interval_time
+  FROM dba_hist_snapshot s
+ WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
+   AND dbid = &&edb360_dbid.
+GROUP BY dbid, snap_id
+), 
+per_snap AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        h.snap_id,
        s.begin_interval_time,
        s.end_interval_time,
        h.avg_wait_time_milli,
        h.avg_avg_wait_time_milli
-  FROM average_average   h,
-       &&awr_object_prefix.snapshot s
+  FROM average_average h,
+       s
  WHERE s.snap_id         = h.snap_id
    AND s.dbid            = h.dbid
-   AND s.instance_number = h.instance_number
 )
 SELECT snap_id,
-       TO_CHAR(MIN(begin_interval_time), 'YYYY-MM-DD HH24:MI:SS') begin_time,
-       TO_CHAR(MIN(end_interval_time), 'YYYY-MM-DD HH24:MI:SS') end_time,
-       ROUND(SUM(avg_wait_time_milli), 3) avg_latency_ms,
-       ROUND(SUM(avg_avg_wait_time_milli), 3) latency_trend_ms,
+       TO_CHAR(begin_interval_time, 'YYYY-MM-DD HH24:MI:SS') begin_time,
+       TO_CHAR(end_interval_time, 'YYYY-MM-DD HH24:MI:SS') end_time,
+       ROUND(avg_wait_time_milli, 3) avg_latency_ms,
+       ROUND(avg_avg_wait_time_milli, 3) latency_trend_ms
        0 dummy_03,
        0 dummy_04,
        0 dummy_05,
@@ -312,9 +320,7 @@ SELECT snap_id,
        0 dummy_13,
        0 dummy_14,
        0 dummy_15
-  FROM per_inst
- GROUP BY
-       snap_id
+  FROM per_snap
  ORDER BY
        snap_id
 ]';
@@ -324,168 +330,168 @@ END;
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_01. "&&event_name_01." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_01.'') AND event_name = TRIM(''&&event_name_01.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_02. "&&event_name_02." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_02.'') AND event_name = TRIM(''&&event_name_02.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_03. "&&event_name_03." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_03.'') AND event_name = TRIM(''&&event_name_03.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_04. "&&event_name_04." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_04.'') AND event_name = TRIM(''&&event_name_04.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_05. "&&event_name_05." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_05.'') AND event_name = TRIM(''&&event_name_05.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_06. "&&event_name_06." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_06.'') AND event_name = TRIM(''&&event_name_06.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_07. "&&event_name_07." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_07.'') AND event_name = TRIM(''&&event_name_07.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_08. "&&event_name_08." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_08.'') AND event_name = TRIM(''&&event_name_08.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_09. "&&event_name_09." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_09.'') AND event_name = TRIM(''&&event_name_09.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_10. "&&event_name_10." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_10.'') AND event_name = TRIM(''&&event_name_10.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_11. "&&event_name_11." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_11.'') AND event_name = TRIM(''&&event_name_11.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_12. "&&event_name_12." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_12.'') AND event_name = TRIM(''&&event_name_12.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_13. "&&event_name_13." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_13.'') AND event_name = TRIM(''&&event_name_13.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_14. "&&event_name_14." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_14.'') AND event_name = TRIM(''&&event_name_14.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_15. "&&event_name_15." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_15.'') AND event_name = TRIM(''&&event_name_15.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_16. "&&event_name_16." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_16.'') AND event_name = TRIM(''&&event_name_16.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_17. "&&event_name_17." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_17.'') AND event_name = TRIM(''&&event_name_17.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_18. "&&event_name_18." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_18.'') AND event_name = TRIM(''&&event_name_18.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_19. "&&event_name_19." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_19.'') AND event_name = TRIM(''&&event_name_19.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_20. "&&event_name_20." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_20.'') AND event_name = TRIM(''&&event_name_20.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_21. "&&event_name_21." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_21.'') AND event_name = TRIM(''&&event_name_21.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_22. "&&event_name_22." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_22.'') AND event_name = TRIM(''&&event_name_22.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_23. "&&event_name_23." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_23.'') AND event_name = TRIM(''&&event_name_23.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql
 
 DEF skip_lch = '';
 DEF title = '&&wait_class_24. "&&event_name_24." Average Latency';
-DEF abstract = 'Trend is computed as average of "Average" so far. Thus "Trend" at time T[N] is average of "Average" between time T[0] and T[N] where N > 0.<br />'
+DEF abstract = 'Trend is computed as Cumulative Weighted Average so far, weighted by the number of waits in each AWR snapshot.<br />'
 DEF vaxis = 'Average Latency and Trend in milliseconds';
 EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'wait_class = TRIM(''&&wait_class_24.'') AND event_name = TRIM(''&&event_name_24.'')');
 @@&&skip_diagnostics.edb360_9a_pre_one.sql

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -17,6 +17,7 @@ COLUMN avg_latency_ms      HEADING 'Average|Latency (ms)'
 COLUMN latency_trend_ms    HEADING 'Latency|Trend (ms)'
 
 --dmk 2.7.2020 correction to wait time calculation to use same formula as in queries for each individual event
+
 BEGIN
   :sql_text := q'[
 WITH
@@ -49,7 +50,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
   FROM events
  WHERE wait_time_milli_total > 0
 )
-SELECT ROUND(wait_time_milli_total / 1000 / 3600, 1) hours_waited,
+SELECT ROUND(wait_time_milli_total / 1000 / 3600, 2) hours_waited,
        wait_count_total,
        wait_time_milli_total/NULLIF(wait_count_total,0) avg_wait_time_milli,
        wait_class,

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -11,8 +11,8 @@ DEF title = 'Top 24 Wait Events';
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
 
 COLUMN hours_waited        HEADING 'Hours|Waited'
-COLUMN wait_count_total    HEADING 'Wait Count|Total'
-COLUMN avg_wait_time_milli HEADING 'Average|Wait Time (ms)'
+COLUMN wait_count_total    HEADING 'Wait Count|Total'       
+COLUMN avg_wait_time_milli HEADING 'Average|Wait Time (ms)' FORMAT 999,999.999
 COLUMN avg_latency_ms      HEADING 'Average|Latency (ms)'
 COLUMN latency_trend_ms    HEADING 'Latency|Trend (ms)'
 

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -258,21 +258,21 @@ COL event_heading_13 NEW_V event_heading_13
 COL event_heading_14 NEW_V event_heading_14
 COL event_heading_15 NEW_V event_heading_15
 
-SELECT REPLACE('&&event_name_01',' ','_') event_heading_01
-,      REPLACE('&&event_name_02',' ','_') event_heading_02
-,      REPLACE('&&event_name_03',' ','_') event_heading_03
-,      REPLACE('&&event_name_04',' ','_') event_heading_04
-,      REPLACE('&&event_name_05',' ','_') event_heading_05
-,      REPLACE('&&event_name_06',' ','_') event_heading_06
-,      REPLACE('&&event_name_07',' ','_') event_heading_07
-,      REPLACE('&&event_name_08',' ','_') event_heading_08
-,      REPLACE('&&event_name_09',' ','_') event_heading_09
-,      REPLACE('&&event_name_10',' ','_') event_heading_10
-,      REPLACE('&&event_name_11',' ','_') event_heading_11
-,      REPLACE('&&event_name_12',' ','_') event_heading_12
-,      REPLACE('&&event_name_13',' ','_') event_heading_13
-,      REPLACE('&&event_name_14',' ','_') event_heading_14
-,      REPLACE('&&event_name_15',' ','_') event_heading_15
+SELECT REGEXP_REPLACE('&&event_name_01','[^A-Za-z0-9]+','_') event_heading_01
+,      REGEXP_REPLACE('&&event_name_02','[^A-Za-z0-9]+','_') event_heading_02
+,      REGEXP_REPLACE('&&event_name_03','[^A-Za-z0-9]+','_') event_heading_03
+,      REGEXP_REPLACE('&&event_name_04','[^A-Za-z0-9]+','_') event_heading_04
+,      REGEXP_REPLACE('&&event_name_05','[^A-Za-z0-9]+','_') event_heading_05
+,      REGEXP_REPLACE('&&event_name_06','[^A-Za-z0-9]+','_') event_heading_06
+,      REGEXP_REPLACE('&&event_name_07','[^A-Za-z0-9]+','_') event_heading_07
+,      REGEXP_REPLACE('&&event_name_08','[^A-Za-z0-9]+','_') event_heading_08
+,      REGEXP_REPLACE('&&event_name_09','[^A-Za-z0-9]+','_') event_heading_09
+,      REGEXP_REPLACE('&&event_name_10','[^A-Za-z0-9]+','_') event_heading_10
+,      REGEXP_REPLACE('&&event_name_11','[^A-Za-z0-9]+','_') event_heading_11
+,      REGEXP_REPLACE('&&event_name_12','[^A-Za-z0-9]+','_') event_heading_12
+,      REGEXP_REPLACE('&&event_name_13','[^A-Za-z0-9]+','_') event_heading_13
+,      REGEXP_REPLACE('&&event_name_14','[^A-Za-z0-9]+','_') event_heading_14
+,      REGEXP_REPLACE('&&event_name_15','[^A-Za-z0-9]+','_') event_heading_15
   FROM DUAL;
 
 BEGIN

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -235,9 +235,10 @@ DEF tit_13 = '';
 DEF tit_14 = '';
 DEF tit_15 = '';
 
-REM dmk 1.7.2020 - removed wait_class_id from analytic partition by clause
-REM switched to cumulative average waited by number of events counted instead of average of equally weighted averages, 
-REM removed group by instance, and sum per instance in final query.
+--dmk 1.7.2020 - removed wait_class_id from analytic partition by clause
+--switched to cumulative average waited by number of events counted instead of average of equally weighted averages, 
+--removed group by instance, and sum per instance in final query.
+
 BEGIN
   :sql_text_backup := q'[
 WITH
@@ -306,7 +307,7 @@ SELECT snap_id,
        TO_CHAR(begin_interval_time, 'YYYY-MM-DD HH24:MI:SS') begin_time,
        TO_CHAR(end_interval_time, 'YYYY-MM-DD HH24:MI:SS') end_time,
        ROUND(avg_wait_time_milli, 3) avg_latency_ms,
-       ROUND(avg_avg_wait_time_milli, 3) latency_trend_ms
+       ROUND(avg_avg_wait_time_milli, 3) latency_trend_ms,
        0 dummy_03,
        0 dummy_04,
        0 dummy_05,

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -16,7 +16,7 @@ COLUMN avg_wait_time_milli HEADING 'Average|Wait Time (ms)' FORMAT 999,999.999
 COLUMN avg_latency_ms      HEADING 'Average|Latency (ms)'
 COLUMN latency_trend_ms    HEADING 'Latency|Trend (ms)'
 
---dmk 2.7.2020 correction to wait time calculation
+--dmk 2.7.2020 correction to wait time calculation to use same formula as in queries for each individual event
 BEGIN
   :sql_text := q'[
 WITH
@@ -51,7 +51,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
 )
 SELECT ROUND(wait_time_milli_total / 1000 / 3600, 1) hours_waited,
        wait_count_total,
-       wait_time_milli_total/NULLIF(wait_count_total,0) avg_wait_timi_milli,
+       wait_time_milli_total/NULLIF(wait_count_total,0) avg_wait_time_milli,
        wait_class,
        event_name
   FROM ranked

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -242,21 +242,21 @@ DEF tit_13 = '&&event_name_13.';
 DEF tit_14 = '&&event_name_14.';
 DEF tit_15 = '&&event_name_15.';
 
-COL event_heading_01 NEW_V event_heading_01 HEADING '"&&event_name_01"' FORMAT 999,999.999
-COL event_heading_02 NEW_V event_heading_02 HEADING '"&&event_name_02"' FORMAT 999,999.999
-COL event_heading_03 NEW_V event_heading_03 HEADING '"&&event_name_03"' FORMAT 999,999.999
-COL event_heading_04 NEW_V event_heading_04 HEADING '"&&event_name_04"' FORMAT 999,999.999
-COL event_heading_05 NEW_V event_heading_05 HEADING '"&&event_name_05"' FORMAT 999,999.999
-COL event_heading_06 NEW_V event_heading_06 HEADING '"&&event_name_06"' FORMAT 999,999.999
-COL event_heading_07 NEW_V event_heading_07 HEADING '"&&event_name_07"' FORMAT 999,999.999
-COL event_heading_08 NEW_V event_heading_08 HEADING '"&&event_name_08"' FORMAT 999,999.999
-COL event_heading_09 NEW_V event_heading_09 HEADING '"&&event_name_09"' FORMAT 999,999.999
-COL event_heading_10 NEW_V event_heading_10 HEADING '"&&event_name_10"' FORMAT 999,999.999
-COL event_heading_11 NEW_V event_heading_11 HEADING '"&&event_name_11"' FORMAT 999,999.999
-COL event_heading_12 NEW_V event_heading_12 HEADING '"&&event_name_12"' FORMAT 999,999.999
-COL event_heading_13 NEW_V event_heading_13 HEADING '"&&event_name_13"' FORMAT 999,999.999
-COL event_heading_14 NEW_V event_heading_14 HEADING '"&&event_name_14"' FORMAT 999,999.999
-COL event_heading_15 NEW_V event_heading_15 HEADING '"&&event_name_15"' FORMAT 999,999.999
+COL event_heading_01 NEW_V event_heading_01 
+COL event_heading_02 NEW_V event_heading_02 
+COL event_heading_03 NEW_V event_heading_03 
+COL event_heading_04 NEW_V event_heading_04 
+COL event_heading_05 NEW_V event_heading_05 
+COL event_heading_06 NEW_V event_heading_06 
+COL event_heading_07 NEW_V event_heading_07 
+COL event_heading_08 NEW_V event_heading_08 
+COL event_heading_09 NEW_V event_heading_09 
+COL event_heading_10 NEW_V event_heading_10 
+COL event_heading_11 NEW_V event_heading_11 
+COL event_heading_12 NEW_V event_heading_12 
+COL event_heading_13 NEW_V event_heading_13 
+COL event_heading_14 NEW_V event_heading_14 
+COL event_heading_15 NEW_V event_heading_15 
 
 SELECT REGEXP_REPLACE('&&event_name_01','[^A-Za-z0-9]+','_') event_heading_01
 ,      REGEXP_REPLACE('&&event_name_02','[^A-Za-z0-9]+','_') event_heading_02
@@ -274,6 +274,22 @@ SELECT REGEXP_REPLACE('&&event_name_01','[^A-Za-z0-9]+','_') event_heading_01
 ,      REGEXP_REPLACE('&&event_name_14','[^A-Za-z0-9]+','_') event_heading_14
 ,      REGEXP_REPLACE('&&event_name_15','[^A-Za-z0-9]+','_') event_heading_15
   FROM DUAL;
+
+COL &&event_heading_01 HEADING '"&&event_name_01"' FORMAT 999,999.999
+COL &&event_heading_02 HEADING '"&&event_name_02"' FORMAT 999,999.999
+COL &&event_heading_03 HEADING '"&&event_name_03"' FORMAT 999,999.999
+COL &&event_heading_04 HEADING '"&&event_name_04"' FORMAT 999,999.999
+COL &&event_heading_05 HEADING '"&&event_name_05"' FORMAT 999,999.999
+COL &&event_heading_06 HEADING '"&&event_name_06"' FORMAT 999,999.999
+COL &&event_heading_07 HEADING '"&&event_name_07"' FORMAT 999,999.999
+COL &&event_heading_08 HEADING '"&&event_name_08"' FORMAT 999,999.999
+COL &&event_heading_09 HEADING '"&&event_name_09"' FORMAT 999,999.999
+COL &&event_heading_10 HEADING '"&&event_name_10"' FORMAT 999,999.999
+COL &&event_heading_11 HEADING '"&&event_name_11"' FORMAT 999,999.999
+COL &&event_heading_12 HEADING '"&&event_name_12"' FORMAT 999,999.999
+COL &&event_heading_13 HEADING '"&&event_name_13"' FORMAT 999,999.999
+COL &&event_heading_14 HEADING '"&&event_name_14"' FORMAT 999,999.999
+COL &&event_heading_15 HEADING '"&&event_name_15"' FORMAT 999,999.999
 
 BEGIN
   :sql_text := q'[

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -343,7 +343,7 @@ DEF tit_15 = '';
 --removed group by instance, and sum per instance in final query.
 
 BEGIN
-  :sql_text_backup := q'[
+  :sql_text := q'[
 WITH
 histogram AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */

--- a/sql/edb360_5c_ash_top.sql
+++ b/sql/edb360_5c_ash_top.sql
@@ -235,7 +235,6 @@ WITH
 hist AS (
 SELECT /*+ &&sq_fact_hints. &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3. */
        /* &&section_id..&&report_sequence. */
-       &&skip_noncdb.con_id,
        sql_id,
        dbid,
        program,
@@ -248,7 +247,6 @@ SELECT /*+ &&sq_fact_hints. &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3.
    AND snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
  GROUP BY
-       &&skip_noncdb.con_id,
        sql_id,
        dbid,
        program,
@@ -267,7 +265,6 @@ SELECT SUBSTR(TRIM(h.sql_id||' '||h.program||' '||
        &&awr_object_prefix.sqltext s
  WHERE h.samples >= t.samples / 1000 AND rn <= 14
    AND s.sql_id(+) = h.sql_id AND s.dbid(+) = h.dbid
-   &&skip_noncdb.AND s.con_id(+) = h.con_id
  UNION ALL
 SELECT 'Others' source,
        NVL(SUM(h.samples), 0) samples,

--- a/sql/edb360_6c_ash_sql.sql
+++ b/sql/edb360_6c_ash_sql.sql
@@ -13,7 +13,6 @@ BEGIN
 WITH
 hist AS (
 SELECT /*+ &&sq_fact_hints. &&ds_hint. */ /* &&section_id..&&report_sequence. */
-       &&skip_noncdb.con_id,
        sql_id,
        ROW_NUMBER () OVER (ORDER BY COUNT(*) DESC) rn,
        COUNT(*) samples
@@ -21,7 +20,6 @@ SELECT /*+ &&sq_fact_hints. &&ds_hint. */ /* &&section_id..&&report_sequence. */
  WHERE @filter_predicate@
    AND sql_id IS NOT NULL
  GROUP BY
-       &&skip_noncdb.con_id,
        sql_id
 ),
 total AS (
@@ -37,7 +35,6 @@ SELECT DISTINCT
        &&gv_object_prefix.sql v2
  WHERE h.samples >= t.samples / 1000 AND rn <= 14
    AND v2.sql_id(+) = h.sql_id
-   &&skip_ver_le_11.AND v2.con_id(+) = h.con_id
  UNION ALL
 SELECT 'Others',
        NVL(SUM(h.samples), 0) samples,

--- a/sql/edb360_6c_ash_sql.sql
+++ b/sql/edb360_6c_ash_sql.sql
@@ -104,7 +104,6 @@ WITH
 hist AS (
 SELECT /*+ &&sq_fact_hints. &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3. */
        /* &&section_id..&&report_sequence. */
-       &&skip_noncdb.con_id,
        sql_id,
        dbid,
        ROW_NUMBER () OVER (ORDER BY COUNT(*) DESC) rn,
@@ -115,7 +114,6 @@ SELECT /*+ &&sq_fact_hints. &&ds_hint. &&ash_hints1. &&ash_hints2. &&ash_hints3.
    AND snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
  GROUP BY
-       &&skip_noncdb.con_id,
        sql_id,
        dbid
 ),
@@ -132,7 +130,6 @@ SELECT DISTINCT
        &&awr_object_prefix.sqltext s
  WHERE h.samples >= t.samples / 1000 AND rn <= 14
    AND s.sql_id(+) = h.sql_id AND s.dbid(+) = h.dbid
-   &&skip_noncdb.AND s.con_id(+) = h.con_id
  UNION ALL
 SELECT 'Others',
        NVL(SUM(h.samples), 0) samples,


### PR DESCRIPTION
Some of the CDB changes in sections 4a to 4e have been reversed because they are breaking the generation of the line charts.
Additional charts have been added to 4a to report the behaviour of the shared_pool, larger_pool, java_pool and streams_pool across each PDB when edb360 is run in the root container.

A number of changes and corrections have been made in section 4h
1. The calculation of the total time waited for the top 25 events has been corrected.  Previously the totals did not agree with ASH data.  Now the same formula as the per event queries has been used (with the CASE statement on wait_time_mili).  Hours waited is now shown to 2 decimal places.  Some column titles have been specifically set and formatted.
1. A new line chart has been added showing the average latency per snap of top 15 wait events over time.  The idea being that artefacts of interest are when latencies for some events scale differently to that for others.  This is where the lines cross.
1. The calculation of the latency trend has been changed.  Previously it was the average of the average latency for each snap accumulated over all the samples up to that point in the report.  However, this gave equal weight to all of the samples.  So a different latency at a quiet time had an undue influence on the trend.  Instead, the new calculation uses a weighted average, where the weight is the number of waits for each event.  This is done by summing all the wait time to date and dividing it by the sum of the number of weights to date.