### PR TITLE
Corrections to Latency Histogram Calculations based on DBA_HIST_EVENT_HISTOGRAM

### DIFF
--- a/sql/edb360_2a_admin.sql
+++ b/sql/edb360_2a_admin.sql
@@ -15,7 +15,7 @@ BEGIN
 select v.*
 from
   (select
-      name, inst_id,
+      latch#, name, addr, inst_id,
       gets,
       misses,
       round(misses*100/(gets+1), 3) misses_gets_pct,

--- a/sql/edb360_4f_io_waits.sql
+++ b/sql/edb360_4f_io_waits.sql
@@ -76,7 +76,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */ 
-       (wait_time_milli - LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.

--- a/sql/edb360_4f_io_waits.sql
+++ b/sql/edb360_4f_io_waits.sql
@@ -67,9 +67,12 @@ DEF chartype = 'AreaChart';
 DEF stacked = 'isStacked: true,';
 
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
+     , MAX(wait_time_milli)*1.5 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
- WHERE dbid = &&edb360_dbid.;
+ WHERE dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9;
 
 BEGIN
   :sql_text_backup := q'[
@@ -81,12 +84,11 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */ 
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
-   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 history AS (

--- a/sql/edb360_4f_io_waits.sql
+++ b/sql/edb360_4f_io_waits.sql
@@ -74,9 +74,9 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        snap_id,
        dbid,
        instance_number,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */ 
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap,
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */ 
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -250,7 +250,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.

--- a/sql/edb360_4f_io_waits.sql
+++ b/sql/edb360_4f_io_waits.sql
@@ -69,7 +69,7 @@ DEF stacked = 'isStacked: true,';
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
 COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
-     , MAX(wait_time_milli)*1.5 max_wait_time_milli
+     , MAX(wait_time_milli)*2 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE dbid = &&edb360_dbid.
    AND wait_time_milli < 1e9;

--- a/sql/edb360_4g_io_waits_top_histog.sql
+++ b/sql/edb360_4g_io_waits_top_histog.sql
@@ -16,8 +16,8 @@ details AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -132,8 +132,8 @@ details AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
    FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -273,8 +273,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.

--- a/sql/edb360_4g_io_waits_top_histog.sql
+++ b/sql/edb360_4g_io_waits_top_histog.sql
@@ -10,7 +10,7 @@ SPO OFF;
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
 COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
-     , MAX(wait_time_milli)*1.5 max_wait_time_milli
+     , MAX(wait_time_milli)*2 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE dbid = &&edb360_dbid.
    AND wait_time_milli < 1e9;

--- a/sql/edb360_4g_io_waits_top_histog.sql
+++ b/sql/edb360_4g_io_waits_top_histog.sql
@@ -8,9 +8,12 @@ PRO <ol start="&&report_sequence.">
 SPO OFF;
 
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
+     , MAX(wait_time_milli)*1.5 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
- WHERE dbid = &&edb360_dbid.;
+ WHERE dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9;
 
 DEF title = 'Top 24 Wait Events';
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
@@ -22,13 +25,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
-   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -139,13 +141,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
    FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
-   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -281,12 +282,11 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
-   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 history AS (

--- a/sql/edb360_4g_io_waits_top_histog.sql
+++ b/sql/edb360_4g_io_waits_top_histog.sql
@@ -17,7 +17,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - wait_time_milli/4)  /* middle of the bucket */ 
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -133,7 +133,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - wait_time_milli/4)  /* middle of the bucket */ 
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
    FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -274,7 +274,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - wait_time_milli/4)  /* middle of the bucket */ 
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.

--- a/sql/edb360_4g_io_waits_top_histog.sql
+++ b/sql/edb360_4g_io_waits_top_histog.sql
@@ -7,6 +7,11 @@ PRO <h2>&&section_id.. &&section_name.</h2>
 PRO <ol start="&&report_sequence.">
 SPO OFF;
 
+COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+SELECT MIN(wait_time_milli) min_wait_time_milli
+  FROM &&awr_object_prefix.event_histogram
+ WHERE dbid = &&edb360_dbid.;
+
 DEF title = 'Top 24 Wait Events';
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
 BEGIN
@@ -17,12 +22,13 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -133,12 +139,13 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
    FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -274,11 +281,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 history AS (

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -26,8 +26,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -142,8 +142,8 @@ details AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -320,8 +320,8 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
        snap_id,
        event_name,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
   FROM dba_hist_event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -416,8 +416,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -142,7 +142,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -26,7 +26,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -36,7 +37,7 @@ events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap) wait_time_milli_total,
+       SUM(average_wait_time_milli * wait_count_this_snap) wait_time_milli_total,
        SUM(wait_count_this_snap) wait_count_total
   FROM details
  GROUP BY
@@ -319,7 +320,8 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
        snap_id,
        event_name,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
   FROM dba_hist_event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -329,7 +331,7 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
        dbid,
        snap_id,
        event_name,
-       ROUND(SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/NULLIF(SUM(wait_count_this_snap),0),3) avg_wait_time_milli
+       ROUND(SUM(average_wait_time_milli * wait_count_this_snap)/NULLIF(SUM(wait_count_this_snap),0),3) avg_wait_time_milli
   FROM histogram
  WHERE wait_count_this_snap >= 0
  GROUP BY
@@ -414,7 +416,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -424,7 +427,7 @@ average AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        snap_id,
        dbid,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap) snap_wait_time_milli,
+       SUM(average_wait_time_milli * wait_count_this_snap) snap_wait_time_milli,
        SUM(wait_count_this_snap) wait_count_this_snap
   FROM histogram
  WHERE wait_count_this_snap >= 0

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -406,7 +406,7 @@ DEF tit_15 = '';
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
 COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
-     , MAX(wait_time_milli)*1.5 max_wait_time_milli
+     , MAX(wait_time_milli)*2 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE dbid = &&edb360_dbid.
    AND wait_time_milli < 1e9;

--- a/sql/edb360_4h_io_waits_top_trend.sql
+++ b/sql/edb360_4h_io_waits_top_trend.sql
@@ -27,11 +27,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        event_name,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -143,12 +144,13 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli = &&min_wait_time_milli. THEN 1 ELSE 0.75 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -321,10 +323,11 @@ SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
        event_name,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) average_wait_time_milli
   FROM dba_hist_event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9
 ),
 average AS (
 SELECT /*+  MATERIALIZE NO_MERGE  */ /* 4h.2 */
@@ -407,6 +410,10 @@ DEF tit_15 = '';
 --switched to cumulative average waited by number of events counted instead of average of equally weighted averages, 
 --removed group by instance, and sum per instance in final query.
 
+COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+SELECT MIN(wait_time_milli) min_wait_time_milli
+  FROM &&awr_object_prefix.event_histogram
+ WHERE dbid = &&edb360_dbid.;
 BEGIN
   :sql_text_backup := q'[
 WITH
@@ -417,10 +424,11 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 average AS (

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -10,7 +10,7 @@ SPO OFF;
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
 COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
-     , MAX(wait_time_milli)*1.5 max_wait_time_milli
+     , MAX(wait_time_milli)*2 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE dbid = &&edb360_dbid.
    AND wait_time_milli < 1e9;

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -17,7 +17,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -133,7 +133,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli - LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id  ORDER BY wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -7,6 +7,11 @@ PRO <h2>&&section_id.. &&section_name.</h2>
 PRO <ol start="&&report_sequence.">
 SPO OFF;
 
+COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+SELECT MIN(wait_time_milli) min_wait_time_milli
+  FROM &&awr_object_prefix.event_histogram
+ WHERE dbid = &&edb360_dbid.;
+
 DEF title = 'Top 24 Wait Events';
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
 BEGIN
@@ -17,12 +22,13 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -133,12 +139,13 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
+   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -245,10 +252,11 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 average AS (

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -17,7 +17,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -244,7 +244,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id) wait_count_this_snap
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
@@ -256,7 +257,7 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        SUM(wait_count_this_snap) waits_count_this_snap,
-       SUM((CASE wait_time_milli WHEN 1 THEN 0.50 ELSE 0.75 END) * wait_time_milli * wait_count_this_snap)/SUM(wait_count_this_snap) avg_wait_time_milli
+       SUM(average_wait_time_milli * wait_count_this_snap)/SUM(wait_count_this_snap) avg_wait_time_milli
   FROM histogram
  WHERE wait_count_this_snap >= 0
  GROUP BY

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -16,8 +16,8 @@ details AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, snap_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -132,8 +132,8 @@ details AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 /* average wait_time_milli */
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
@@ -244,8 +244,8 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        dbid,
        instance_number,
        wait_time_milli,
-       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_class_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY snap_id, dbid, instance_number, event_id, wait_class_id ORDER BY wait_time_milli),wait_time_milli)) / 2 average_wait_time_milli
+       (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
+       (wait_time_milli + NVL(LAG(wait_time_milli) OVER (PARTITION BY dbid, instance_number, event_id, snap_id ORDER BY wait_time_milli),0)) / 2 average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.

--- a/sql/edb360_4i_io_waits_top_relation.sql
+++ b/sql/edb360_4i_io_waits_top_relation.sql
@@ -8,9 +8,12 @@ PRO <ol start="&&report_sequence.">
 SPO OFF;
 
 COLUMN min_wait_time_milli NEW_VALUE min_wait_time_milli
+COLUMN max_wait_time_milli NEW_VALUE max_wait_time_milli
 SELECT MIN(wait_time_milli) min_wait_time_milli
+     , MAX(wait_time_milli)*1.5 max_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
- WHERE dbid = &&edb360_dbid.;
+ WHERE dbid = &&edb360_dbid.
+   AND wait_time_milli < 1e9;
 
 DEF title = 'Top 24 Wait Events';
 DEF main_table = '&&awr_hist_prefix.EVENT_HISTOGRAM';
@@ -22,13 +25,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
-   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -139,13 +141,12 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        wait_class,
        event_name,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) * /* wait_count_this_snap */
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) /* average wait_time_milli */
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) /* average wait_time_milli */
        wait_time_milli_total
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
    AND wait_class <> 'Idle'
-   AND wait_time_milli < 1e9
 ),
 events AS (
 SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
@@ -252,11 +253,10 @@ SELECT /*+ &&sq_fact_hints. */ /* &&section_id..&&report_sequence. */
        instance_number,
        wait_time_milli,
        (wait_count - LAG(wait_count) OVER (PARTITION BY dbid, instance_number, event_id, wait_time_milli ORDER BY snap_id)) wait_count_this_snap,
-       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*wait_time_milli) average_wait_time_milli
+       ((CASE WHEN wait_time_milli > &&min_wait_time_milli. THEN 0.75 ELSE 0.5 END)*LEAST(wait_time_milli,&&max_wait_time_milli.)) average_wait_time_milli
   FROM &&awr_object_prefix.event_histogram
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
-   AND wait_time_milli < 1e9
    AND @filter_predicate@
 ),
 average AS (


### PR DESCRIPTION
1. Corrections to Latency Histogram Calculations based on DBA_HIST_EVENT_HISTOGRAM
The duration of the histogram bucket in some summary reports (was being calculated as half the difference in the upper limit for the current and previous lower bucket.  Therefore, these reports were returning incorrect values.  
Also, not all bucket sizes will be present for all events in all snapshots so we cannot use the LAG() function approach either.  Therefore it is safer to use 3/4 of the bucket size (because the upper limit of the next lower bucket will be 1/2 size of this bucket).
In some places, the code was written to assume the smallest bucket was 1ms, but in 19c has smaller buckets (down to .000976563ms).  The code now looks up the smallest known bucket size in DBA_HIST_EVENT_HISTORY and uses 3/4 of that value for larger buckets.

WAIT_CLASS_ID has been removed from the partition by clauses in the analytic functions because they already contain EVENT_ID.  

Oracle reports a histogram with a wait_timi_milli of 1.8014E+16.  This is 570,000 years!  So, it is effectively infinite.  The excessive value for the bucket size distorts the calculations so instead, it is capped at 2 the value of the next bucket.  This continues the geometric progression that every bucket is twice as long as the previous, and still counts the very long waits that fall into the highest bucket.

2. Also: Latch number and address has been added to the latch report in 2a.  Although it is not referenced elsewhere in EDB360, it can be extracted from p1 and p2 in the ASH data that is extracted to a flat file, so it would be useful to be able to look it up somewhere in EDB360.
