### PR TITLE
ordering query against %_registry_sqlpatch by patch_id, install_id

### DIFF
--- a/sql/edb360_1a_configuration.sql
+++ b/sql/edb360_1a_configuration.sql
@@ -375,7 +375,7 @@ SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
        &&skip_noncdb.,c.name con_name
   FROM &&cdb_object_prefix.registry_sqlpatch x
        &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
- ORDER BY 1
+ ORDER BY patch_id, install_id
 	   &&skip_noncdb.,x.con_id
 ]';
 END;


### PR DESCRIPTION
I recently noticed that it is possible to see multiple install_ids per patch_id (plus status -> "completed with errors") until the RU/RUR is successfully applied. Ordering by patch_id and install_id makes it easier to understand the current status at one glance