### PR TITLE
better order-by clause in %_registry_sqlpatch

### DIFF
--- a/sql/edb360_1a_configuration.sql
+++ b/sql/edb360_1a_configuration.sql
@@ -375,7 +375,7 @@ SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
        &&skip_noncdb.,c.name con_name
   FROM &&cdb_object_prefix.registry_sqlpatch x
        &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
- ORDER BY 1
+ ORDER BY patch_id, install_id
 	   &&skip_noncdb.,x.con_id
 ]';
 END;

--- a/sql/edb360_1a_configuration.sql
+++ b/sql/edb360_1a_configuration.sql
@@ -375,7 +375,9 @@ SELECT /*+ &&top_level_hints. */ /* &&section_id..&&report_sequence. */
        &&skip_noncdb.,c.name con_name
   FROM &&cdb_object_prefix.registry_sqlpatch x
        &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
- ORDER BY patch_id, install_id
+ ORDER BY 
+     &&skip_ver_le_12_1  2,
+     1
 	   &&skip_noncdb.,x.con_id
 ]';
 END;


### PR DESCRIPTION
This fix sorts entries in dba|cdb_registry_sqlpatch by patch_id, install_id (from 12.2 onwards) or patch_id (12.1)