### PR TITLE
Query in 4a "dmk begin SGASTAT per PDB per INSTANCE" fails in non-pdb

### DIFF
--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -250,11 +250,13 @@ SELECT con_id,
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
 GROUP BY con_id
+), fake as (select null name from dual
 ), y AS (
 SELECT row_number() OVER (ORDER BY sga_total DESC) wrank,
        x.con_id, 'PDB_'||x.con_id||'_'||c.name con_name
 FROM   x
        &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
+       &&skip_cdb. cross join fake c
 ), z AS (
 SELECT row_number() OVER (ORDER BY con_id) wrank,
        y.con_id, y.con_name


### PR DESCRIPTION
When the db is non-pdb the query fails because the column projected name in line 255 has table alias "c" which belongs to the table containers from the join that is skipped by skip_nocdb.