### PR TITLE
Fix for issue #80 : Query in edb360_4a_sga_stats.sql not non-CDB comp…

### DIFF
--- a/sql/edb360_4a_sga_stats.sql
+++ b/sql/edb360_4a_sga_stats.sql
@@ -244,12 +244,15 @@ DEF tit_14 = '';
 DEF tit_15 = '';
 
 WITH x AS (
-SELECT con_id,
+SELECT &&skip_noncdb.con_id,
+       &&skip_cdb.TO_NUMBER(null) con_id,
        SUM(bytes) sga_total
   FROM &&awr_object_prefix.sgastat
  WHERE snap_id BETWEEN &&minimum_snap_id. AND &&maximum_snap_id.
    AND dbid = &&edb360_dbid.
-GROUP BY con_id
+GROUP BY
+       &&skip_noncdb.con_id,
+       null
 ), fake as (select null name from dual
 ), y AS (
 SELECT row_number() OVER (ORDER BY sga_total DESC) wrank,


### PR DESCRIPTION
Reference: Issue #80 

Query on line **247** of file `edb360_4a_sga_stats.sql` is not non-CDB compatible.

Resolved using the `&&skip_noncdb.` and `&&skip_cdb.` variables in the query and added a trailing constant/static `null` to **GROUP BY** statement to make it syntactically correct for non-container databases (since we can't group by an alias).
