### PR TITLE
Add case to 2d Unrecoverable Datafile after Backup

### DIFF
--- a/sql/edb360_2d_rman.sql
+++ b/sql/edb360_2d_rman.sql
@@ -743,10 +743,11 @@ FROM   &&v_object_prefix.datafile df
 WHERE  df.file#=bk.file#
 and    df.unrecoverable_change#!=0
 and    df.unrecoverable_time >
-       (select max(end_time)
+    NVL((select max(end_time)
 	    FROM   &&v_object_prefix.rman_backup_job_details
         where  INPUT_TYPE in ('DB FULL' ,'DB INCR')
 		and    status = 'COMPLETED')
+    ,to_date('01/01/1900','dd/mm/yyyy'))
 ]';
 END;
 /


### PR DESCRIPTION
Include case where DB has no backup yet.

Fix for 2d Unrecoverable Datafile after Backup
Note: No data to corroborate.  Zero rows but verified query did not failed.

12.1 ora_smon_lab1211            0 Rows  
12.1 ora_smon_cdb1211   CDB$ROOT 0 Rows  PDBCOLV1 0  PDBJBA 0 
19.0 ora_smon_x6191              0 Rows
18.1 ora_smon_enkpoem1           1 Rows       
19.0 ora_smon_boston1            0 Rows
12.2 ora_smon_x61221             0 Rows
12.2 ora_smon_cdb1221   CDB$ROOT 0 Rows  PDBCJK 0  PDBUPG1 0 PDBUPG2 0

11.2.0.4 x4 ORCL 0 Rows