### PR TITLE
7b remodel for fixes and performance

### DIFF
--- a/sql/edb360_3b_plan_stability.sql
+++ b/sql/edb360_3b_plan_stability.sql
@@ -248,13 +248,24 @@ END;
 DEF title = 'SQL Plan Directives - Objects';
 DEF main_table = '&&cdb_view_prefix.SQL_PLAN_DIR_OBJECTS';
 BEGIN
+/*  Bug 20683085 - ANYDATA and XMLTYPE columns do not work with Cross Container object queries (ORA-12805 and ORA-7445 [kprcdt] possible) (Doc ID 20683085.8)
+  dba_sql_plan_dir_objects.notes is xmltype 
+*/
+ if '&&DB_VERSION.' = '12.1.0.2.0' and '&&IS_CDB.' ='Y' then 
   :sql_text := q'[
+SELECT *
+  FROM &&dva_object_prefix.sql_plan_dir_objects
+ ORDER BY 1,2,3,4,5
+]';
+else
+  :sql_text :=
 SELECT x.*
        &&skip_noncdb.,c.name con_name
   FROM &&cdb_object_prefix.sql_plan_dir_objects x
        &&skip_noncdb.LEFT OUTER JOIN &&v_object_prefix.containers c ON c.con_id = x.con_id
  ORDER BY 1,2,3,4,5
 ]';
+end if;
 END;
 /
 @@&&skip_ver_le_11.edb360_9a_pre_one.sql

--- a/sql/sqld360_0c_post.sql
+++ b/sql/sqld360_0c_post.sql
@@ -63,14 +63,13 @@ HOS zip -mq &&sqld360_main_filename._&&sqld360_file_time. &&sqld360_main_report.
 HOS zip -mq &&sqld360_main_filename._&&sqld360_file_time. 00000_readme_first.txt 
 --HOS unzip -l &&sqld360_main_filename._&&sqld360_file_time.
 
-
 -- This commit is to end the transaction we initiated in this execution
 -- The main goal is to avoid ORA-65023 when switching to another PDB
 COMMIT;
 
 -- here we need to switch back to caller CONTAINER (CDB/PDB)
 -- It will error out in versions before 12c, safe to ignore
-&&skip_noncdb.ALTER SESSION SET CONTAINER=&&sqld360_container.;
+ALTER SESSION SET CONTAINER=&&sqld360_container.;
 
 
 --update plan table with zip file for eDB360 to pull
@@ -78,3 +77,4 @@ UPDATE plan_table SET remarks = '&&sqld360_main_filename._&&sqld360_file_time..z
 COMMIT;
 
 SET TERM ON;
+

--- a/sqld360.sql
+++ b/sqld360.sql
@@ -74,13 +74,13 @@ BEGIN
      AND remarks IS NULL;
 
   -- 1708 - Extracting calling container (only in 12c)
+  -- 2202 - Run Regarless of version.
   BEGIN
     SELECT SYS_CONTEXT('USERENV','CON_NAME')
       INTO container
-      FROM v$instance
-     WHERE version LIKE '12%';
+      FROM DUAL;
   EXCEPTION
-     WHEN NO_DATA_FOUND THEN container := ''; -- not in 12c
+     WHEN OTHERS THEN container := ''; -- not a cdb
   END;
 
   IF num_sqlids = 0 THEN


### PR DESCRIPTION
The 7b section was remodel to fix several issues:
- The ora-32034 when materializing the WITH clauses
- The syntactic errors depending on RDBMS versions and multi-tenant architecture
- The sqld360 generated files failed to be added to the edb360 main file
- Generating SQLs for duplicate SQLIDs, for PL/SQLs and other SQLs that the SQLD360 is not designed to collect info from
- SQL texts sometimes empty

The complexity of the driving query makes the maintenance and implementation of criteria more difficult
and an all-or-nothing result, meaning if one section failed for whatever reason no SQLD360 or planx is generated.

The driving way replaced by 3 materializations of the 3 criteria used to identify SQLs to generate the SQLD360 and Planx.
The materializations use PLAN_TABLE to hold the rows.
The PLAN_TABLE is not going to hold more rows than the sum of &&edb360_conf_top_sql + &&edb360_conf_top_cur + &&edb360_conf_top_sig .

The top_sql materialization looks for INSERT,UPDATES,DELETS,SELECT, CTAS AND CREATE MVS
that have at least 10 minutes of accumulated DB time.
excludes the SQLS coming from edb360,sqld360,MMON process and auto-stats job.

The top_not_shared materialization looks for SQLs that have a high version count larger than 100 in the library cache.
The dba_hist_sqlstat has a record of the SQLs having high version count but the information from v$sql_shared_cursors is
not persistent in the AWR as of 19c so that is why on this materialization looks for the SQLs in the library cache.
It is expensive but at this time there is no other way.
Excludes the SQLs from top_sql because the sqld360 is already captured for them.

The top_signature materialization looks for SQLs that have high DB time grouped by force_matching_signature.
No SQLs is excluded like in "top_sql" because if it is possible that any group of SQLs including our own to generate multiple literal SQLs
that cause a high impact we want to know.
Excludes the SQLs from top_sql and top_non_shared because the sqld360 is already captured for them.

The materialized rows then are matched to their respective pdb_name and username.
The rows are matched with their SQL text using multiple sources without considering the corresponding pdb because the SQLID is hash of the SQL Text so it is the same
regardless that the SQL is executed in multiple PDBs.